### PR TITLE
Ship headers from ui/shell_dialogs

### DIFF
--- a/script/create-dist
+++ b/script/create-dist
@@ -3,6 +3,7 @@
 import errno
 import os
 import shutil
+import subprocess
 
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))


### PR DESCRIPTION
The shell_dialogs contains some classes to create file dialogs. It's already compiled in libchromiumcontent but the headers are not shipped.
