### PR TITLE
Add net_with_v8 as dependency of chromiumcontent.

### DIFF
--- a/chromiumcontent/chromiumcontent.gyp
+++ b/chromiumcontent/chromiumcontent.gyp
@@ -48,6 +48,7 @@
         '<(DEPTH)/content/content.gyp:content',
         '<(DEPTH)/content/content.gyp:content_app_both',
         '<(DEPTH)/content/content.gyp:content_shell_pak',
+        '<(DEPTH)/net/net.gyp:net_with_v8',
       ],
       'sources': [
         'empty.cc',


### PR DESCRIPTION
When setting the proxy service it would randomly crash the application if using the "SystemProxyResolver", and it is not used by Chromium too. We need to use "ProxyResolverV8" instead, which is well tested and included by net_with_v8.

net_with_v8 only contains 6 files and no new dependencies, and we should use the "ProxyResolverV8" in brightray to improve stability, so I think making it a direct dependency of chromiumcontent is fine.
