### PR TITLE
Build test_support_base into test_support_chromiumcontent

### DIFF
--- a/chromiumcontent/chromiumcontent.gyp
+++ b/chromiumcontent/chromiumcontent.gyp
@@ -104,6 +104,7 @@
               'action_name': 'Create libtest_support_chromiumcontent.a',
               'inputs': [
                 '<(PRODUCT_DIR)/obj/base/libbase_prefs_test_support.a',
+                '<(PRODUCT_DIR)/obj/base/libtest_support_base.a',
                 '<(PRODUCT_DIR)/obj/testing/libgmock.a',
                 '<(PRODUCT_DIR)/obj/testing/libgtest.a',
                 '<(PRODUCT_DIR)/obj/net/libnet_test_support.a',
@@ -129,6 +130,7 @@
               'action_name': 'Create libtest_support_chromiumcontent.a',
               'inputs': [
                 '<(PRODUCT_DIR)/libbase_prefs_test_support.a',
+                '<(PRODUCT_DIR)/libtest_support_base.a',
                 '<(PRODUCT_DIR)/libgmock.a',
                 '<(PRODUCT_DIR)/libgtest.a',
                 '<(PRODUCT_DIR)/libnet_test_support.a',
@@ -155,6 +157,7 @@
               'action_name': 'Create test_support_chromiumcontent.lib',
               'inputs': [
                 '<(PRODUCT_DIR)\\obj\\base\\base_prefs_test_support.lib',
+                '<(PRODUCT_DIR)\\obj\\base\\test_support_base.lib',
                 '<(PRODUCT_DIR)\\obj\\base\\test_support_base.lib',
                 '<(PRODUCT_DIR)\\obj\\content\\test_support_content.lib',
                 '<(PRODUCT_DIR)\\obj\\net\\net_test_support.lib',


### PR DESCRIPTION
This includes things like libxml2, which is needed for Chromium's custom unit test runner.
