### PR TITLE
use custom, fixed for gsutil svn checkout

### DIFF
--- a/vendor/chromium/.gclient.in
+++ b/vendor/chromium/.gclient.in
@@ -18,6 +18,7 @@ solutions = [
       "src/chrome/tools/test/reference_build/chrome_linux": None,
       "src/chrome/tools/test/reference_build/chrome_mac": None,
       "src/third_party/hunspell_dictionaries": None,
+      "build/third_party/gsutil" : "svn://svn.chromium.org/gsutil/trunk/src@263",
     },
   },
 ]


### PR DESCRIPTION
gsutil is no longer available via the URL that the DEPS file in the Chrome source says it is: http://gsutil.googlecode.com/svn/trunk/src

But it is available here: svn://svn.chromium.org/gsutil/trunk/src

(This is a known upstream issue, fixed in Chrome 32.  See [here](https://groups.google.com/a/chromium.org/forum/#!topic/chromium-dev/1QJpKAvlQqw) and [here](https://code.google.com/p/chromium/issues/detail?id=334327).)

Here, we'll override the URL with `.gclient.in` so we can keep building with Chrome 31.
