### PR TITLE
Enable customing commit of libchromiumcontent to download.

### DIFF
--- a/script/download
+++ b/script/download
@@ -29,7 +29,10 @@ class ProgramError(Exception):
 def main():
     try:
         args = parse_args()
-        commit = head_commit()
+        if args.commit == 'HEAD':
+            commit = head_commit()
+        else:
+            commit = args.commit
         base_url = '{0}/{1}'.format(args.url, PLATFORM_KEY)
         download_if_needed(args.path, base_url, commit, force=args.force)
         if not args.symbols:
@@ -46,6 +49,8 @@ def parse_args():
                         help='Overwrite destination if it already exists.')
     parser.add_argument('-s', '--symbols', action='store_true',
                         help='Download debugging symbols as well.')
+    parser.add_argument('-c', '--commit', nargs='?', default='HEAD',
+                        help='The commit of libchromiumcontent to download.')
     parser.add_argument('url', help='The base URL from which to download '
                         '(i.e., the URL you passed to script/upload)')
     parser.add_argument('path', help='The path to extract to')


### PR DESCRIPTION
Currently using a custom fork of libchromiumcontent would require forking brightray too, this PR helps avoiding that.
