### PR TITLE
Also ship with libEGL.dll on Windows.

### DIFF
--- a/script/create-dist
+++ b/script/create-dist
@@ -55,6 +55,7 @@ BINARIES = {
         'chromiumviews.lib',
         'ffmpegsumo.dll',
         'icudt.dll',
+        'libEGL.dll',
         'libGLESv2.dll',
         'test_support_chromiumcontent.lib',
         os.path.join('obj', 'base', 'base_static.lib'),


### PR DESCRIPTION
It's critical for supporting WebGL.
