### PR TITLE
Fix hittest not working correctly on non client mouse messages on high DPI Windows

### DIFF
--- a/patches/events_win.patch
+++ b/patches/events_win.patch
@@ -1,0 +1,13 @@
+Index: ui/events/win/events_win.cc
+===================================================================
+--- ui/events/win/events_win.cc	(revision 274914)
++++ ui/events/win/events_win.cc	(working copy)
+@@ -236,7 +236,7 @@
+     native_point.y = GET_Y_LPARAM(native_event.lParam);
+   }
+   ScreenToClient(native_event.hwnd, &native_point);
+-  return gfx::win::ScreenToDIPPoint(gfx::Point(native_point));
++  return gfx::Point(native_point);
+ }
+ 
+ gfx::Point EventSystemLocationFromNative(


### PR DESCRIPTION
Imported from:
http://src.chromium.org/viewvc/chrome?view=revision&revision=265722
