### PR TITLE
Use GCC on 32bit Linux

### DIFF
--- a/chromiumcontent/chromiumcontent.gypi
+++ b/chromiumcontent/chromiumcontent.gypi
@@ -28,6 +28,10 @@
         # Enable high DPI support on Linux.
         'enable_hidpi': 1,
       }],
+      ['OS=="linux" and host_arch=="ia32"', {
+        # Use GCC on 32bit Linux.
+        'clang': 0,
+      }],
     ],
     'global_defines': [
       'COMPONENT_BUILD',


### PR DESCRIPTION
From Chrome 38, Chromium has started to use its own clang binaries for building by default, however its clang binaries only have 64bit build so it requires a 32bit chroot environment on a 64bit machine with special setup to build for 32bit target, see [Switch linux to use clang by default](https://code.google.com/p/chromium/issues/detail?id=360311).

In order to make building easier, we just use GCC for building on 32bit host machines.
