### PR TITLE
:memo: Update required VS2013 version on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ TODO
 
 #### Windows
 
-* Visual Studio 2013 Professional Update 2
+* Visual Studio 2013 Professional Update 4
 
 #### Linux
 


### PR DESCRIPTION
Currently, the minimal required version of VS2013 for building Chromium is Update 4. See https://www.chromium.org/developers/how-tos/build-instructions-windows

As far as I know, VS2013 Update 2 cannot build Chrome41.