### PR TITLE
Add `--component` argument to specify building type.

### DIFF
--- a/script/build
+++ b/script/build
@@ -25,17 +25,19 @@ def main():
   os.chdir(SOURCE_ROOT)
 
   for component in COMPONENTS:
-    out_dir = os.path.join(VENDOR_DIR, 'chromium', 'src',
-                           get_output_dir(target_arch, component))
-
-    config = get_configuration(target_arch)
-    config_dir = os.path.relpath(os.path.join(out_dir, config))
-    subprocess.check_call([NINJA, '-C', config_dir] + TARGETS)
+    if args.component == 'all' or args.component == component:
+      out_dir = os.path.join(VENDOR_DIR, 'chromium', 'src',
+                             get_output_dir(target_arch, component))
+      config = get_configuration(target_arch)
+      config_dir = os.path.relpath(os.path.join(out_dir, config))
+      subprocess.check_call([NINJA, '-C', config_dir] + TARGETS)
 
 
 def parse_args():
   parser = argparse.ArgumentParser(description='Build libchromiumcontent')
   parser.add_argument('-t', '--target_arch', default='x64', help='x64 or ia32')
+  parser.add_argument('-c', '--component', default='all',
+                      help='static_library or shared_library or all')
   return parser.parse_args()
 
 

--- a/script/create-dist
+++ b/script/create-dist
@@ -160,9 +160,10 @@ def main():
   os.makedirs(DIST_DIR)
 
   for component in COMPONENTS:
-    output_dir = os.path.join(SRC_DIR, get_output_dir(target_arch, component))
-    copy_binaries(target_arch, component, output_dir)
-    copy_generated_sources(target_arch, component, output_dir)
+    if args.component == 'all' or args.component == component:
+      output_dir = os.path.join(SRC_DIR, get_output_dir(target_arch, component))
+      copy_binaries(target_arch, component, output_dir)
+      copy_generated_sources(target_arch, component, output_dir)
 
   copy_sources()
   create_zip()
@@ -171,6 +172,8 @@ def main():
 def parse_args():
   parser = argparse.ArgumentParser(description='Create distribution')
   parser.add_argument('-t', '--target_arch', default='x64', help='x64 or ia32')
+  parser.add_argument('-c', '--component', default='all',
+                      help='static_library or shared_library or all')
   return parser.parse_args()
 
 


### PR DESCRIPTION
The building script will build `static_library` and `shared_library` at one time, which requires a lot of time. It would be better to add a switch argument allowing developers to choose the specific building type. @zcbenz PLTAL