### PR TITLE
Ship pdf component as a shared library

### DIFF
--- a/patches/export_pdf.patch
+++ b/patches/export_pdf.patch
@@ -1,8 +1,8 @@
 diff --git a/pdf/pdf.cc b/pdf/pdf.cc
-index 7aba412..246cd81 100644
+index 7aba412..f57902a 100644
 --- a/pdf/pdf.cc
 +++ b/pdf/pdf.cc
-@@ -81,21 +81,26 @@ const void* PPP_GetInterface(const char* interface_name) {
+@@ -81,7 +81,13 @@ const void* PPP_GetInterface(const char* interface_name) {
    return pp::Module::Get()->GetPluginInterface(interface_name);
  }
  
@@ -12,58 +12,26 @@ index 7aba412..246cd81 100644
 +extern "C" {
 +
  #if defined(OS_WIN)
--bool RenderPDFPageToDC(const void* pdf_buffer,
--                                 int buffer_size,
--                                 int page_number,
--                                 HDC dc,
--                                 int dpi,
--                                 int bounds_origin_x,
--                                 int bounds_origin_y,
--                                 int bounds_width,
--                                 int bounds_height,
--                                 bool fit_to_bounds,
--                                 bool stretch_to_bounds,
--                                 bool keep_aspect_ratio,
--                                 bool center_in_bounds,
--                                 bool autorotate) {
-+PDF_EXPORT bool RenderPDFPageToDC(const void* pdf_buffer,
-+                                  int buffer_size,
-+                                  int page_number,
-+                                  HDC dc,
-+                                  int dpi,
-+                                  int bounds_origin_x,
-+                                  int bounds_origin_y,
-+                                  int bounds_width,
-+                                  int bounds_height,
-+                                  bool fit_to_bounds,
-+                                  bool stretch_to_bounds,
-+                                  bool keep_aspect_ratio,
-+                                  bool center_in_bounds,
-+                                  bool autorotate) {
-   if (!g_sdk_initialized_via_pepper) {
-     if (!chrome_pdf::InitializeSDK()) {
-       return false;
-@@ -118,9 +123,9 @@ bool RenderPDFPageToDC(const void* pdf_buffer,
++PDF_EXPORT
+ bool RenderPDFPageToDC(const void* pdf_buffer,
+                                  int buffer_size,
+                                  int page_number,
+@@ -118,6 +124,7 @@ bool RenderPDFPageToDC(const void* pdf_buffer,
  
  #endif  // OS_WIN
  
--bool GetPDFDocInfo(const void* pdf_buffer,
--                   int buffer_size, int* page_count,
--                   double* max_page_width) {
-+PDF_EXPORT bool GetPDFDocInfo(const void* pdf_buffer,
-+                              int buffer_size, int* page_count,
-+                              double* max_page_width) {
-   if (!g_sdk_initialized_via_pepper) {
-     if (!chrome_pdf::InitializeSDK())
-       return false;
-@@ -176,4 +181,4 @@ bool RenderPDFPageToBitmap(const void* pdf_buffer,
++PDF_EXPORT
+ bool GetPDFDocInfo(const void* pdf_buffer,
+                    int buffer_size, int* page_count,
+                    double* max_page_width) {
+@@ -176,4 +183,4 @@ bool RenderPDFPageToBitmap(const void* pdf_buffer,
    return ret;
  }
  
 -}  // namespace chrome_pdf
 +}
 diff --git a/pdf/pdf.gyp b/pdf/pdf.gyp
-index f47e33a..6e0a12d 100644
+index f47e33a..19864bb 100644
 --- a/pdf/pdf.gyp
 +++ b/pdf/pdf.gyp
 @@ -6,7 +6,7 @@
@@ -75,44 +43,25 @@ index f47e33a..6e0a12d 100644
        'dependencies': [
          '../base/base.gyp:base',
          '../components/components.gyp:ui_zoom',
-@@ -17,6 +17,9 @@
-         '../third_party/pdfium/pdfium.gyp:pdfium',
-       ],
-       'ldflags': [ '-L<(PRODUCT_DIR)',],
-+      'defines': [
-+        'PDF_IMPLEMENTATION',
-+      ],
-       'sources': [
-         'button.h',
-         'button.cc',
 diff --git a/pdf/pdf.h b/pdf/pdf.h
-index 37e72e5..37e7112 100644
+index 37e72e5..3f80208 100644
 --- a/pdf/pdf.h
 +++ b/pdf/pdf.h
-@@ -5,6 +5,22 @@
+@@ -5,6 +5,13 @@
  #ifndef PDF_PDF_H_
  #define PDF_PDF_H_
  
 +#if defined(WIN32)
-+
-+#if defined(PDF_IMPLEMENTATION)
 +#define PDF_EXPORT __declspec(dllexport)
-+#define PDF_EXPORT_PRIVATE __declspec(dllexport)
-+#else
-+#define PDF_EXPORT __declspec(dllimport)
-+#define PDF_EXPORT_PRIVATE __declspec(dllimport)
-+#endif  // defined(PDF_IMPLEMENTATION)
-+
 +#else
 +#define PDF_EXPORT
-+#define PDF_EXPORT_PRIVATE
-+#endif
++#endif // defined(WIN32)
 +
 +
  #include "ppapi/c/ppb.h"
  #include "ppapi/cpp/module.h"
  
-@@ -25,6 +41,7 @@ int PPP_InitializeModule(PP_Module module_id,
+@@ -25,6 +32,7 @@ int PPP_InitializeModule(PP_Module module_id,
  void PPP_ShutdownModule();
  const void* PPP_GetInterface(const char* interface_name);
  
@@ -120,7 +69,7 @@ index 37e72e5..37e7112 100644
  #if defined(OS_WIN)
  // |pdf_buffer| is the buffer that contains the entire PDF document to be
  //     rendered.
-@@ -108,6 +125,8 @@ bool RenderPDFPageToBitmap(const void* pdf_buffer,
+@@ -108,6 +116,8 @@ bool RenderPDFPageToBitmap(const void* pdf_buffer,
                             int dpi,
                             bool autorotate);
  

--- a/patches/export_pdf.patch
+++ b/patches/export_pdf.patch
@@ -1,0 +1,131 @@
+diff --git a/pdf/pdf.cc b/pdf/pdf.cc
+index 7aba412..246cd81 100644
+--- a/pdf/pdf.cc
++++ b/pdf/pdf.cc
+@@ -81,21 +81,26 @@ const void* PPP_GetInterface(const char* interface_name) {
+   return pp::Module::Get()->GetPluginInterface(interface_name);
+ }
+ 
++}  // namespace chrome_pdf
++
++
++extern "C" {
++
+ #if defined(OS_WIN)
+-bool RenderPDFPageToDC(const void* pdf_buffer,
+-                                 int buffer_size,
+-                                 int page_number,
+-                                 HDC dc,
+-                                 int dpi,
+-                                 int bounds_origin_x,
+-                                 int bounds_origin_y,
+-                                 int bounds_width,
+-                                 int bounds_height,
+-                                 bool fit_to_bounds,
+-                                 bool stretch_to_bounds,
+-                                 bool keep_aspect_ratio,
+-                                 bool center_in_bounds,
+-                                 bool autorotate) {
++PDF_EXPORT bool RenderPDFPageToDC(const void* pdf_buffer,
++                                  int buffer_size,
++                                  int page_number,
++                                  HDC dc,
++                                  int dpi,
++                                  int bounds_origin_x,
++                                  int bounds_origin_y,
++                                  int bounds_width,
++                                  int bounds_height,
++                                  bool fit_to_bounds,
++                                  bool stretch_to_bounds,
++                                  bool keep_aspect_ratio,
++                                  bool center_in_bounds,
++                                  bool autorotate) {
+   if (!g_sdk_initialized_via_pepper) {
+     if (!chrome_pdf::InitializeSDK()) {
+       return false;
+@@ -118,9 +123,9 @@ bool RenderPDFPageToDC(const void* pdf_buffer,
+ 
+ #endif  // OS_WIN
+ 
+-bool GetPDFDocInfo(const void* pdf_buffer,
+-                   int buffer_size, int* page_count,
+-                   double* max_page_width) {
++PDF_EXPORT bool GetPDFDocInfo(const void* pdf_buffer,
++                              int buffer_size, int* page_count,
++                              double* max_page_width) {
+   if (!g_sdk_initialized_via_pepper) {
+     if (!chrome_pdf::InitializeSDK())
+       return false;
+@@ -176,4 +181,4 @@ bool RenderPDFPageToBitmap(const void* pdf_buffer,
+   return ret;
+ }
+ 
+-}  // namespace chrome_pdf
++}
+diff --git a/pdf/pdf.gyp b/pdf/pdf.gyp
+index f47e33a..6e0a12d 100644
+--- a/pdf/pdf.gyp
++++ b/pdf/pdf.gyp
+@@ -6,7 +6,7 @@
+   'targets': [
+     {
+       'target_name': 'pdf',
+-      'type': 'static_library',
++      'type': 'loadable_module',
+       'dependencies': [
+         '../base/base.gyp:base',
+         '../components/components.gyp:ui_zoom',
+@@ -17,6 +17,9 @@
+         '../third_party/pdfium/pdfium.gyp:pdfium',
+       ],
+       'ldflags': [ '-L<(PRODUCT_DIR)',],
++      'defines': [
++        'PDF_IMPLEMENTATION',
++      ],
+       'sources': [
+         'button.h',
+         'button.cc',
+diff --git a/pdf/pdf.h b/pdf/pdf.h
+index 37e72e5..37e7112 100644
+--- a/pdf/pdf.h
++++ b/pdf/pdf.h
+@@ -5,6 +5,22 @@
+ #ifndef PDF_PDF_H_
+ #define PDF_PDF_H_
+ 
++#if defined(WIN32)
++
++#if defined(PDF_IMPLEMENTATION)
++#define PDF_EXPORT __declspec(dllexport)
++#define PDF_EXPORT_PRIVATE __declspec(dllexport)
++#else
++#define PDF_EXPORT __declspec(dllimport)
++#define PDF_EXPORT_PRIVATE __declspec(dllimport)
++#endif  // defined(PDF_IMPLEMENTATION)
++
++#else
++#define PDF_EXPORT
++#define PDF_EXPORT_PRIVATE
++#endif
++
++
+ #include "ppapi/c/ppb.h"
+ #include "ppapi/cpp/module.h"
+ 
+@@ -25,6 +41,7 @@ int PPP_InitializeModule(PP_Module module_id,
+ void PPP_ShutdownModule();
+ const void* PPP_GetInterface(const char* interface_name);
+ 
++#if 0
+ #if defined(OS_WIN)
+ // |pdf_buffer| is the buffer that contains the entire PDF document to be
+ //     rendered.
+@@ -108,6 +125,8 @@ bool RenderPDFPageToBitmap(const void* pdf_buffer,
+                            int dpi,
+                            bool autorotate);
+ 
++#endif
++
+ }  // namespace chrome_pdf
+ 
+ #endif  // PDF_PDF_H_

--- a/script/create-dist
+++ b/script/create-dist
@@ -73,20 +73,12 @@ BINARIES = {
     'libGLESv2.dll',
     'libyuv.lib',
     'mksnapshot.exe',
+    'pdf.dll',
     os.path.join('lib', 'ffmpegsumo.lib'),
     os.path.join('obj', 'base', 'base_static.cc.pdb'),
     os.path.join('obj', 'base', 'base_static.lib'),
     os.path.join('obj', 'sandbox', 'sandbox.cc.pdb'),
     os.path.join('obj', 'sandbox', 'sandbox.lib'),
-    # pdf component related libraries
-    os.path.join('obj', 'pdf', 'pdf.cc.pdb'),
-    os.path.join('obj', 'pdf', 'pdf.lib'),
-    os.path.join('obj', 'ppapi', 'ppapi_cpp_objects.cc.pdb'),
-    os.path.join('obj', 'ppapi', 'ppapi_cpp_objects.lib'),
-    os.path.join('obj', 'ppapi', 'ppapi_internal_module.cc.pdb'),
-    os.path.join('obj', 'ppapi', 'ppapi_internal_module.lib'),
-    os.path.join('obj', 'components', 'ui_zoom.cc.pdb'),
-    os.path.join('obj', 'components', 'ui_zoom.lib'),
   ],
 }
 
@@ -124,7 +116,6 @@ INCLUDE_DIRS = [
   'mojo',
   'net',
   'printing',
-  'pdf',
   'ppapi',
   'sandbox',
   'skia',
@@ -214,13 +205,6 @@ def copy_binaries(target_arch, component, output_dir):
         if os.path.exists(lib):
           shutil.copy2(dll, target_dir)
           shutil.copy2(lib, target_dir)
-      # copy all pdfium libraries (out/Release/obj/third_party/pdfium/*.lib)
-      pdfium_dir = os.path.join(config_dir, 'obj', 'third_party', 'pdfium')
-      for root, _, filenames in os.walk(pdfium_dir):
-        for filename in fnmatch.filter(filenames, '*.lib'):
-          shutil.copy2(os.path.join(root, filename), target_dir)
-        for filename in fnmatch.filter(filenames, '*.pdb'):
-          shutil.copy2(os.path.join(root, filename), target_dir)
     else:
       # On Windows static libraries are placed under subdirs under "obj".
       for root, _, filenames in os.walk(os.path.join(config_dir, 'obj')):


### PR DESCRIPTION
This patch makes the pdf library build from static_library to shared_library. As a side effect, we only ship the pdf.dll, and no need to ship all the pdf related libraries.