### PR TITLE
ftp: including generated network resource

### DIFF
--- a/script/create-dist
+++ b/script/create-dist
@@ -153,6 +153,7 @@ INCLUDE_DIRS = [
 GENERATED_INCLUDE_DIRS = [
   'content',
   'mojo',
+  'net',
   'ui',
 ]
 OTHER_HEADERS = [


### PR DESCRIPTION
[IDR_DIR_HEADER_HTML](https://code.google.com/p/chromium/codesearch#chromium/src/out/Debug/gen/net/grit/net_resources.h&q=dir_header.html&sq=package:chromium&type=cs&l=5) is required for directory listing.