### PR TITLE
Fix pdf.dll link error in component builds after upgrade to Chrome 43.

### DIFF
--- a/patches/export_pdf.patch
+++ b/patches/export_pdf.patch
@@ -31,7 +31,7 @@ index 7aba412..f57902a 100644
 -}  // namespace chrome_pdf
 +}
 diff --git a/pdf/pdf.gyp b/pdf/pdf.gyp
-index f47e33a..19864bb 100644
+index f47e33a..26207ea 100644
 --- a/pdf/pdf.gyp
 +++ b/pdf/pdf.gyp
 @@ -6,7 +6,7 @@
@@ -43,13 +43,21 @@ index f47e33a..19864bb 100644
        'dependencies': [
          '../base/base.gyp:base',
          '../components/components.gyp:ui_zoom',
+@@ -14,6 +14,7 @@
+         '../net/net.gyp:net',
+         '../ppapi/ppapi.gyp:ppapi_cpp_objects',
+         '../ppapi/ppapi.gyp:ppapi_internal_module',
++        '../printing/printing.gyp:printing',
+         '../third_party/pdfium/pdfium.gyp:pdfium',
+       ],
+       'ldflags': [ '-L<(PRODUCT_DIR)',],
 diff --git a/pdf/pdf.h b/pdf/pdf.h
-index 37e72e5..3f80208 100644
+index 37e72e5..6a31fc6 100644
 --- a/pdf/pdf.h
 +++ b/pdf/pdf.h
-@@ -5,6 +5,13 @@
- #ifndef PDF_PDF_H_
- #define PDF_PDF_H_
+@@ -8,6 +8,13 @@
+ #include "ppapi/c/ppb.h"
+ #include "ppapi/cpp/module.h"
  
 +#if defined(WIN32)
 +#define PDF_EXPORT __declspec(dllexport)
@@ -58,9 +66,9 @@ index 37e72e5..3f80208 100644
 +#endif // defined(WIN32)
 +
 +
- #include "ppapi/c/ppb.h"
- #include "ppapi/cpp/module.h"
+ namespace chrome_pdf {
  
+ class PDFModule : public pp::Module {
 @@ -25,6 +32,7 @@ int PPP_InitializeModule(PP_Module module_id,
  void PPP_ShutdownModule();
  const void* PPP_GetInterface(const char* interface_name);
@@ -69,12 +77,12 @@ index 37e72e5..3f80208 100644
  #if defined(OS_WIN)
  // |pdf_buffer| is the buffer that contains the entire PDF document to be
  //     rendered.
-@@ -108,6 +116,8 @@ bool RenderPDFPageToBitmap(const void* pdf_buffer,
+@@ -107,7 +115,7 @@ bool RenderPDFPageToBitmap(const void* pdf_buffer,
+                            int bitmap_height,
                             int dpi,
                             bool autorotate);
- 
+-
 +#endif
-+
  }  // namespace chrome_pdf
  
  #endif  // PDF_PDF_H_


### PR DESCRIPTION
The link error in [#115](https://github.com/atom/libchromiumcontent/pull/115#issuecomment-104879030)  is caused by https://codereview.chromium.org/980053002/. We need to add printing component dependency in `pdf` library.

Having test on component-build/non-component-build, as well as test printing feature in `electron`.