### PR TITLE
fix creation of httpresponseheaders from raw_headers

### DIFF
--- a/patches/resource_request_details.patch
+++ b/patches/resource_request_details.patch
@@ -1,23 +1,36 @@
 diff --git a/content/public/browser/resource_request_details.cc b/content/public/browser/resource_request_details.cc
-index ad5f47e..0873a32 100644
+index ad5f47e..4e87c72 100644
 --- a/content/public/browser/resource_request_details.cc
 +++ b/content/public/browser/resource_request_details.cc
-@@ -22,6 +22,10 @@ ResourceRequestDetails::ResourceRequestDetails(const net::URLRequest* request,
-       ssl_cert_id(cert_id),
-       ssl_cert_status(request->ssl_info().cert_status),
-       socket_address(request->GetSocketAddress()) {
-+  if (request->response_info().headers.get())
-+    headers = new net::HttpResponseHeaders(
-+        request->response_info().headers->raw_headers());
-+
-   const ResourceRequestInfo* info = ResourceRequestInfo::ForRequest(request);
-   resource_type = info->GetResourceType();
-   render_frame_id = info->GetRenderFrameID();
+@@ -6,6 +6,7 @@
+ 
+ #include "content/public/browser/resource_request_info.h"
+ #include "net/http/http_response_headers.h"
++#include "net/http/http_util.h"
+ #include "net/url_request/url_request.h"
+ 
+ namespace content {
+@@ -29,6 +30,11 @@ ResourceRequestDetails::ResourceRequestDetails(const net::URLRequest* request,
+       request->response_info().headers.get() ?
+           request->response_info().headers.get()->response_code() : -1;
+   origin_child_id = info->GetChildID();
++  if (request->response_info().headers.get()) {
++    std::string raw_headers = request->response_info().headers->raw_headers();
++    headers = new net::HttpResponseHeaders(net::HttpUtil::AssembleRawHeaders(
++        raw_headers.c_str(), raw_headers.size()));
++  }
+ }
+ 
+ ResourceRequestDetails::~ResourceRequestDetails() {}
 diff --git a/content/public/browser/resource_request_details.h b/content/public/browser/resource_request_details.h
-index f776f4d..af13e87 100644
+index f776f4d..227439e 100644
 --- a/content/public/browser/resource_request_details.h
 +++ b/content/public/browser/resource_request_details.h
-@@ -10,6 +10,7 @@
+@@ -7,9 +7,11 @@
+ 
+ #include <string>
+ 
++#include "base/memory/ref_counted.h"
  #include "content/public/common/resource_type.h"
  #include "net/base/host_port_pair.h"
  #include "net/cert/cert_status_flags.h"
@@ -25,7 +38,7 @@ index f776f4d..af13e87 100644
  #include "net/url_request/url_request_status.h"
  #include "url/gurl.h"
  
-@@ -43,6 +44,7 @@ struct ResourceRequestDetails {
+@@ -43,6 +45,7 @@ struct ResourceRequestDetails {
    // HTTP response code. See HttpResponseHeaders::response_code().
    // -1 if there are no response headers yet.
    int http_response_code;


### PR DESCRIPTION
`httpresponseheaders.parse` needs [null](https://code.google.com/p/chromium/codesearch#chromium/src/net/http/http_response_headers.h&sq=package:chromium&l=70&q=http_response_headers) terminated string, this patch fixes it.