### PR TITLE
Use relative paths in filenames.gypi

### DIFF
--- a/script/create-dist
+++ b/script/create-dist
@@ -169,6 +169,7 @@ def main():
       copy_generated_sources(target_arch, component, output_dir)
 
   copy_sources()
+  generate_filenames_gypi()
   create_zip()
 
 
@@ -306,6 +307,14 @@ def run_ar_combine(filename, target_dir):
   target = os.path.join(target_dir, os.path.basename(filename))
   ar_combine = os.path.join(SOURCE_ROOT, 'tools', 'linux', 'ar-combine.sh')
   subprocess.check_call([ar_combine, '-o', target, filename])
+
+
+def generate_filenames_gypi():
+  generate = os.path.join(SOURCE_ROOT, 'tools', 'generate_filenames_gypi.py')
+  subprocess.check_call([sys.executable, generate,
+                         os.path.join(MAIN_DIR, 'filenames.gypi'),
+                         os.path.join(MAIN_DIR, 'shared_library'),
+                         os.path.join(MAIN_DIR, 'static_library')])
 
 
 def create_zip():

--- a/script/download
+++ b/script/download
@@ -44,7 +44,6 @@ def main():
       download(args.path, base_url, commit, STATIC_LIBRARY_FILENAME)
     with open(os.path.join(args.path, '.target_arch'), 'w') as f:
       f.write(args.target_arch)
-    generate_filenames_gypi(args.path)
   except ProgramError as e:
     return e.message
 
@@ -129,14 +128,6 @@ def download_and_extract(destination, url):
     sys.stderr.flush()
     with zipfile.ZipFile(t) as z:
       z.extractall(destination)
-
-
-def generate_filenames_gypi(destination):
-  generate = os.path.join(SOURCE_ROOT, 'tools', 'generate_filenames_gypi.py')
-  subprocess.check_call([sys.executable, generate,
-                         os.path.join(destination, 'filenames.gypi'),
-                         os.path.join(destination, 'shared_library'),
-                         os.path.join(destination, 'static_library')])
 
 
 def rm_rf(path):

--- a/tools/generate_filenames_gypi.py
+++ b/tools/generate_filenames_gypi.py
@@ -58,23 +58,23 @@ EXCLUDE_STATIC_LIBRARIES = {
 GYPI_TEMPLATE = """\
 {
   'variables': {
-    'libchromiumcontent_root_dir': %(src)s,
-    'libchromiumcontent_shared_libraries': %(shared_libraries)s,
-    'libchromiumcontent_shared_v8_libraries': %(shared_v8_libraries)s,
-    'libchromiumcontent_static_libraries': %(static_libraries)s,
-    'libchromiumcontent_static_v8_libraries': %(static_v8_libraries)s,
+    'libchromiumcontent_root_dir': '.',
+    'libchromiumcontent_shared_library_files': %(shared_libraries)s,
+    'libchromiumcontent_shared_v8_library_files': %(shared_v8_libraries)s,
+    'libchromiumcontent_static_library_files': %(static_libraries)s,
+    'libchromiumcontent_static_v8_library_files': %(static_v8_libraries)s,
   },
 }
 """
 
 
 def main(target_file, shared_src, static_src):
+  target_dir = os.path.dirname(target_file)
   (shared_libraries, shared_v8_libraries) = searh_files(
-      shared_src, SHARED_LIBRARY_SUFFIX, EXCLUDE_SHARED_LIBRARIES)
+      shared_src, target_dir, SHARED_LIBRARY_SUFFIX, EXCLUDE_SHARED_LIBRARIES)
   (static_libraries, static_v8_libraries) = searh_files(
-      static_src, STATIC_LIBRARY_SUFFIX, EXCLUDE_STATIC_LIBRARIES)
+      static_src, target_dir, STATIC_LIBRARY_SUFFIX, EXCLUDE_STATIC_LIBRARIES)
   content = GYPI_TEMPLATE % {
-    'src': repr(os.path.abspath(os.path.dirname(target_file))),
     'shared_libraries': shared_libraries,
     'shared_v8_libraries': shared_v8_libraries,
     'static_libraries': static_libraries,
@@ -84,11 +84,11 @@ def main(target_file, shared_src, static_src):
     f.write(content)
 
 
-def searh_files(src, suffix, exclude):
+def searh_files(src, root, suffix, exclude):
   files = glob.glob(os.path.join(src, '*.' + suffix))
   files = [f for f in files if os.path.basename(f) not in exclude]
-  return ([os.path.abspath(f) for f in files if not is_v8_library(f)],
-          [os.path.abspath(f) for f in files if is_v8_library(f)])
+  return ([os.path.relpath(f, root) for f in files if not is_v8_library(f)],
+          [os.path.relpath(f, root) for f in files if is_v8_library(f)])
 
 
 def is_v8_library(p):


### PR DESCRIPTION
gyp will convert relative paths to absolute paths for us if we store them in appropriately-named variables. Using gyp's automatic path conversion seems to work better when generating Xcode projects. (For example, gyp was complaining about files from libchromiumcontent being included twice in the project, but that error goes away with this change.)

See https://chromium.googlesource.com/external/gyp/+/master/docs/InputFormatReference.md#Pathname-Relativization for the full explanation of gyp's behavior. The essence is that by naming these variables with `*_files` we get the automatic path conversion behavior.

Also, now that `filenames.gypi` doesn't depend on where libchromiumcontent is extracted, we can generate it at build time and include it in the zip file.

/cc @zcbenz 