### PR TITLE
Cross compile for ia32 target

### DIFF
--- a/chromiumcontent/chromiumcontent.gypi
+++ b/chromiumcontent/chromiumcontent.gypi
@@ -93,17 +93,17 @@
           '-Wl,--detect-odr-violations',
         ],
       }],
-      ['sysroot!=""', {
+    ],
+    'target_conditions': [
+      ['_type=="static_library" and _toolset=="target" and OS=="linux" and component=="static_library"', {
+        'standalone_static_library': 1,
+      }],
+      ['_toolset=="target" and sysroot!=""', {
         'conditions': [
           ['target_arch=="ia32"', {
             'include_dirs': [ '<(sysroot)/usr/include/i386-linux-gnu' ],
           }],
         ],
-      }],
-    ],
-    'target_conditions': [
-      ['_type=="static_library" and _toolset=="target" and OS=="linux" and component=="static_library"', {
-        'standalone_static_library': 1,
       }],
       ['_target_name in <(v8_libraries) + <(icu_libraries)', {
         'xcode_settings': {

--- a/chromiumcontent/chromiumcontent.gypi
+++ b/chromiumcontent/chromiumcontent.gypi
@@ -101,7 +101,11 @@
       }],
       # V8 is force using ia32 as host on a x64 host.
       ['_toolset=="host" and target_arch=="ia32" and sysroot!="" and _target_name in <(v8_libraries) + <(icu_libraries)', {
-        'include_dirs': [ '<(sysroot)/usr/include/i386-linux-gnu' ],
+        'include_dirs': [
+          '<(sysroot)/usr/include/i386-linux-gnu',
+          '<(sysroot)/usr/include/c++/4.6',
+          '<(sysroot)/usr/include/c++/4.6/i486-linux-gnu',
+        ],
       }],
       ['_target_name in <(v8_libraries) + <(icu_libraries)', {
         'xcode_settings': {

--- a/chromiumcontent/chromiumcontent.gypi
+++ b/chromiumcontent/chromiumcontent.gypi
@@ -93,6 +93,13 @@
           '-Wl,--detect-odr-violations',
         ],
       }],
+      ['sysroot!=""', {
+        'conditions': [
+          ['target_arch=="ia32"', {
+            'include_dirs': [ '<(sysroot)/usr/include/i386-linux-gnu' ],
+          }],
+        ],
+      }],
     ],
     'target_conditions': [
       ['_type=="static_library" and _toolset=="target" and OS=="linux" and component=="static_library"', {

--- a/chromiumcontent/chromiumcontent.gypi
+++ b/chromiumcontent/chromiumcontent.gypi
@@ -33,10 +33,21 @@
         'enable_hidpi': 1,
         # Use Dbus.
         'use_dbus': 1,
-      }],
-      ['OS=="linux" and target_arch=="arm"', {
-        'arm_version': 7,
-        'arm_float_abi': 'hard',
+        # Use sysroot for building.
+        'use_sysroot': 1,
+        'conditions': [
+          ['target_arch=="arm"', {
+            'arm_version': 7,
+            'arm_float_abi': 'hard',
+            'sysroot%': '<!(cd <(DEPTH) && pwd -P)/chrome/installer/linux/debian_wheezy_arm-sysroot',
+          }],
+          ['target_arch=="ia32"', {
+            'sysroot%': '<!(cd <(DEPTH) && pwd -P)/chrome/installer/linux/debian_wheezy_i386-sysroot',
+          }],
+          ['target_arch=="x64"', {
+            'sysroot%': '<!(cd <(DEPTH) && pwd -P)/chrome/installer/linux/debian_wheezy_amd64-sysroot',
+          }],
+        ],
       }],
     ],
   },

--- a/chromiumcontent/chromiumcontent.gypi
+++ b/chromiumcontent/chromiumcontent.gypi
@@ -3,8 +3,6 @@
     # Enalbe using proprietary codecs.
     'proprietary_codecs': 1,
     'ffmpeg_branding': 'Chrome',
-    # And the gold's flags are not available in system's ld neither.
-    'linux_use_gold_flags': 0,
     # Make Linux build contain debug symbols, this flag will add '-g' to cflags.
     'linux_dump_symbols': 1,
     # The Linux build of libchromiumcontent.so depends on, but doesn't
@@ -39,9 +37,6 @@
       ['OS=="linux" and target_arch=="arm"', {
         'arm_version': 7,
         'arm_float_abi': 'hard',
-      }],
-      ['OS=="linux" and host_arch=="x64"', {
-        'linux_use_gold_flags': 1,
       }],
     ],
   },

--- a/chromiumcontent/chromiumcontent.gypi
+++ b/chromiumcontent/chromiumcontent.gypi
@@ -39,13 +39,6 @@
           ['target_arch=="arm"', {
             'arm_version': 7,
             'arm_float_abi': 'hard',
-            'sysroot': '<!(cd <(DEPTH) && pwd -P)/chrome/installer/linux/debian_wheezy_arm-sysroot',
-          }],
-          ['target_arch=="ia32"', {
-            'sysroot': '<!(cd <(DEPTH) && pwd -P)/chrome/installer/linux/debian_wheezy_i386-sysroot',
-          }],
-          ['target_arch=="x64"', {
-            'sysroot': '<!(cd <(DEPTH) && pwd -P)/chrome/installer/linux/debian_wheezy_amd64-sysroot',
           }],
         ],
       }],

--- a/chromiumcontent/chromiumcontent.gypi
+++ b/chromiumcontent/chromiumcontent.gypi
@@ -91,12 +91,17 @@
       ['_type=="static_library" and _toolset=="target" and OS=="linux" and component=="static_library"', {
         'standalone_static_library': 1,
       }],
+      # Manually set include dirs.
       ['_toolset=="target" and sysroot!=""', {
         'conditions': [
           ['target_arch=="ia32"', {
             'include_dirs': [ '<(sysroot)/usr/include/i386-linux-gnu' ],
           }],
         ],
+      }],
+      # V8 is force using ia32 as host on a x64 host.
+      ['_toolset=="host" and target_arch=="ia32" and sysroot!="" and _target_name in <(v8_libraries) + <(icu_libraries)', {
+        'include_dirs': [ '<(sysroot)/usr/include/i386-linux-gnu' ],
       }],
       ['_target_name in <(v8_libraries) + <(icu_libraries)', {
         'xcode_settings': {

--- a/chromiumcontent/chromiumcontent.gypi
+++ b/chromiumcontent/chromiumcontent.gypi
@@ -39,13 +39,13 @@
           ['target_arch=="arm"', {
             'arm_version': 7,
             'arm_float_abi': 'hard',
-            'sysroot%': '<!(cd <(DEPTH) && pwd -P)/chrome/installer/linux/debian_wheezy_arm-sysroot',
+            'sysroot': '<!(cd <(DEPTH) && pwd -P)/chrome/installer/linux/debian_wheezy_arm-sysroot',
           }],
           ['target_arch=="ia32"', {
-            'sysroot%': '<!(cd <(DEPTH) && pwd -P)/chrome/installer/linux/debian_wheezy_i386-sysroot',
+            'sysroot': '<!(cd <(DEPTH) && pwd -P)/chrome/installer/linux/debian_wheezy_i386-sysroot',
           }],
           ['target_arch=="x64"', {
-            'sysroot%': '<!(cd <(DEPTH) && pwd -P)/chrome/installer/linux/debian_wheezy_amd64-sysroot',
+            'sysroot': '<!(cd <(DEPTH) && pwd -P)/chrome/installer/linux/debian_wheezy_amd64-sysroot',
           }],
         ],
       }],

--- a/chromiumcontent/chromiumcontent.gypi
+++ b/chromiumcontent/chromiumcontent.gypi
@@ -43,12 +43,6 @@
       ['OS=="linux" and host_arch=="x64"', {
         'linux_use_gold_flags': 1,
       }],
-      ['OS=="linux" and host_arch=="ia32"', {
-        # Use system installed clang for building.
-        'make_clang_dir': '/usr',
-        'clang': 1,
-        'clang_use_chrome_plugins': 0,
-      }],
     ],
   },
   'target_defaults': {
@@ -91,19 +85,6 @@
         # Work around ODR violations.
         'ldflags!': [
           '-Wl,--detect-odr-violations',
-        ],
-      }],
-      ['OS=="linux" and host_arch=="ia32"', {
-        'cflags!': [
-          # Clang 3.4 doesn't support these flags.
-          '-Wno-absolute-value',
-          '-Wno-inconsistent-missing-override',
-          '-Wno-pointer-bool-conversion',
-          '-Wno-tautological-pointer-compare',
-          '-Wno-unused-local-typedef',
-          '-Wno-unused-local-typedefs',
-          '-Wno-undefined-bool-conversion',
-          '-Wno-tautological-undefined-compare',
         ],
       }],
     ],

--- a/script/cibuild
+++ b/script/cibuild
@@ -23,6 +23,10 @@ def main():
   if sys.platform in ['win32', 'cygwin']:
     return (run_ci(['-t', 'ia32']) or
             run_ci(['-t', 'x64']))
+  elif sys.platform == 'linux2':
+    return (run_ci(['-t', 'ia32']) or
+            run_ci(['-t', 'x64']) or
+            run_ci(['-t', 'arm']))
   else:
     return run_ci([])
 

--- a/script/update
+++ b/script/update
@@ -31,6 +31,9 @@ def main():
   if not is_source_tarball_updated(version):
     download_source_tarball(version)
 
+  if sys.platform == 'linux2':
+    install_sysroot()
+
   target_arch = args.target_arch
   return (apply_patches() or
           copy_chromiumcontent_files() or
@@ -90,6 +93,14 @@ def download_source_tarball(version):
   version_file = os.path.join(SRC_DIR, '.version')
   with open(version_file, 'w+') as f:
     f.write(version)
+
+
+def install_sysroot():
+  for arch in ('arm', 'amd64', 'i386'):
+    install = os.path.join(SRC_DIR, 'chrome', 'installer', 'linux',
+                           'sysroot_scripts',
+                           'install-debian.wheezy.sysroot.py')
+    subprocess.check_call([install, '--arch', arch])
 
 
 def tar_xf(filename):

--- a/script/update
+++ b/script/update
@@ -132,9 +132,18 @@ def gyp_env(target_arch, component):
   elif sys.platform == 'linux2' and target_arch in ('arm', 'ia32'):
     # ARM build requires cross compilation.
     env['GYP_CROSSCOMPILE'] = '1'
+    # Sets sysroot.
+    sysroot_dir = os.path.join(SRC_DIR, 'chrome', 'installer', 'linux')
+    if target_arch == 'arm':
+      sysroot = os.path.join(sysroot_dir, 'debian_wheezy_arm-sysroot')
+    elif target_arch == 'ia32':
+      sysroot = os.path.join(sysroot_dir, 'debian_wheezy_i386-sysroot')
+    elif target_arch == 'x64':
+      sysroot = os.path.join(sysroot_dir, 'debian_wheezy_amd64-sysroot')
+    gyp_defines += ' sysroot={0}'.format(sysroot)
 
   # Build 32-bit or 64-bit.
-  gyp_defines += ' ' + 'target_arch={0}'.format(target_arch)
+  gyp_defines += ' target_arch={0}'.format(target_arch)
   env['GYP_DEFINES'] = gyp_defines
 
   # Output directory.

--- a/script/update
+++ b/script/update
@@ -120,7 +120,7 @@ def gyp_env(target_arch, component):
     env['GYP_MSVS_VERSION'] = '2013'
 
   # ARM build requires cross compilation.
-  if target_arch == 'arm':
+  if target_arch in ('arm', 'ia32'):
     env['GYP_CROSSCOMPILE'] = '1'
 
   # Build 32-bit or 64-bit.

--- a/script/update
+++ b/script/update
@@ -129,9 +129,8 @@ def gyp_env(target_arch, component):
     # We have our own.
     env['DEPOT_TOOLS_WIN_TOOLCHAIN'] = '0'
     env['GYP_MSVS_VERSION'] = '2013'
-
-  # ARM build requires cross compilation.
-  if target_arch in ('arm', 'ia32'):
+  elif sys.platform == 'linux2' and target_arch in ('arm', 'ia32'):
+    # ARM build requires cross compilation.
     env['GYP_CROSSCOMPILE'] = '1'
 
   # Build 32-bit or 64-bit.


### PR DESCRIPTION
This PR uses sysroot for building and cross compiles for ia32 target, making it easier to build arm and ia32 targets.