### PR TITLE
Build 32bit target in the same way with arm target on Linux

### DIFF
--- a/chromiumcontent/chromiumcontent.gypi
+++ b/chromiumcontent/chromiumcontent.gypi
@@ -10,6 +10,8 @@
     # any conflicts when linking to binaries or libraries that don't use
     # tcmalloc.
     'linux_use_tcmalloc': 0,
+    # Force using gold linker.
+    'linux_use_bundled_gold': 1,
     # Using libc++ requires building for >= 10.7.
     'mac_deployment_target': '10.8',
     # The 10.8 SDK does not work well with C++11.

--- a/chromiumcontent/chromiumcontent.gypi
+++ b/chromiumcontent/chromiumcontent.gypi
@@ -3,15 +3,6 @@
     # Enalbe using proprietary codecs.
     'proprietary_codecs': 1,
     'ffmpeg_branding': 'Chrome',
-    # Make Linux build contain debug symbols, this flag will add '-g' to cflags.
-    'linux_dump_symbols': 1,
-    # The Linux build of libchromiumcontent.so depends on, but doesn't
-    # provide, tcmalloc by default.  Disabling tcmalloc here also prevents
-    # any conflicts when linking to binaries or libraries that don't use
-    # tcmalloc.
-    'linux_use_tcmalloc': 0,
-    # Force using gold linker.
-    'linux_use_bundled_gold': 1,
     # Using libc++ requires building for >= 10.7.
     'mac_deployment_target': '10.8',
     # The 10.8 SDK does not work well with C++11.
@@ -35,10 +26,22 @@
         'enable_hidpi': 1,
         # Use Dbus.
         'use_dbus': 1,
-      }],
-      ['OS=="linux" and target_arch=="arm"', {
-        'arm_version': 7,
-        'arm_float_abi': 'hard',
+        # Make Linux build contain debug symbols, this flag will add '-g' to
+        # cflags.
+        'linux_dump_symbols': 1,
+        # The Linux build of libchromiumcontent.so depends on, but doesn't
+        # provide, tcmalloc by default.  Disabling tcmalloc here also prevents
+        # any conflicts when linking to binaries or libraries that don't use
+        # tcmalloc.
+        'linux_use_tcmalloc': 0,
+        # Force using gold linker.
+        'linux_use_bundled_gold': 1,
+        'conditions': [
+          ['target_arch=="arm"', {
+            'arm_version': 7,
+            'arm_float_abi': 'hard',
+          }],
+        ],
       }],
     ],
   },

--- a/chromiumcontent/chromiumcontent.gypi
+++ b/chromiumcontent/chromiumcontent.gypi
@@ -3,8 +3,6 @@
     # Enalbe using proprietary codecs.
     'proprietary_codecs': 1,
     'ffmpeg_branding': 'Chrome',
-    # And the gold's flags are not available in system's ld neither.
-    'linux_use_gold_flags': 0,
     # Make Linux build contain debug symbols, this flag will add '-g' to cflags.
     'linux_dump_symbols': 1,
     # The Linux build of libchromiumcontent.so depends on, but doesn't
@@ -39,9 +37,6 @@
       ['OS=="linux" and target_arch=="arm"', {
         'arm_version': 7,
         'arm_float_abi': 'hard',
-      }],
-      ['OS=="linux" and host_arch=="x64"', {
-        'linux_use_gold_flags': 1,
       }],
     ],
   },

--- a/chromiumcontent/chromiumcontent.gypi
+++ b/chromiumcontent/chromiumcontent.gypi
@@ -43,12 +43,6 @@
       ['OS=="linux" and host_arch=="x64"', {
         'linux_use_gold_flags': 1,
       }],
-      ['OS=="linux" and host_arch=="ia32"', {
-        # Use system installed clang for building.
-        'make_clang_dir': '/usr',
-        'clang': 1,
-        'clang_use_chrome_plugins': 0,
-      }],
     ],
   },
   'target_defaults': {
@@ -91,19 +85,6 @@
         # Work around ODR violations.
         'ldflags!': [
           '-Wl,--detect-odr-violations',
-        ],
-      }],
-      ['OS=="linux" and host_arch=="ia32"', {
-        'cflags!': [
-          # Clang 3.4 doesn't support these flags.
-          '-Wno-absolute-value',
-          '-Wno-inconsistent-missing-override',
-          '-Wno-pointer-bool-conversion',
-          '-Wno-tautological-pointer-compare',
-          '-Wno-unused-local-typedef',
-          '-Wno-unused-local-typedefs',
-          '-Wno-undefined-bool-conversion',
-          '-Wno-tautological-undefined-compare',
         ],
       }],
     ],

--- a/script/update
+++ b/script/update
@@ -31,6 +31,9 @@ def main():
   if not is_source_tarball_updated(version):
     download_source_tarball(version)
 
+  if sys.platform == 'linux2':
+    install_sysroot()
+
   target_arch = args.target_arch
   return (apply_patches() or
           copy_chromiumcontent_files() or
@@ -90,6 +93,14 @@ def download_source_tarball(version):
   version_file = os.path.join(SRC_DIR, '.version')
   with open(version_file, 'w+') as f:
     f.write(version)
+
+
+def install_sysroot():
+  for arch in ('arm', 'amd64', 'i386'):
+    install = os.path.join(SRC_DIR, 'chrome', 'installer', 'linux',
+                           'sysroot_scripts',
+                           'install-debian.wheezy.sysroot.py')
+    subprocess.check_call([install, '--arch', arch])
 
 
 def tar_xf(filename):

--- a/script/update
+++ b/script/update
@@ -120,7 +120,7 @@ def gyp_env(target_arch, component):
     env['GYP_MSVS_VERSION'] = '2013'
 
   # ARM build requires cross compilation.
-  if target_arch == 'arm':
+  if target_arch in ('arm', 'ia32'):
     env['GYP_CROSSCOMPILE'] = '1'
 
   # Build 32-bit or 64-bit.

--- a/script/update
+++ b/script/update
@@ -110,21 +110,20 @@ def gyp_env(target_arch, component):
 
   env['GYP_GENERATORS'] = 'ninja'
 
-  if sys.platform == 'darwin':
-    # host_arch seems to be required.
-    gyp_defines += ' ' + 'host_arch=x64'
-  elif sys.platform in ['win32', 'cygwin']:
+  if sys.platform in ['win32', 'cygwin']:
     # Don't use the auto-installed VS2013 Express toolchain from depot_tools.
     # We have our own.
     env['DEPOT_TOOLS_WIN_TOOLCHAIN'] = '0'
     env['GYP_MSVS_VERSION'] = '2013'
-
-  # ARM build requires cross compilation.
-  if target_arch in ('arm', 'ia32'):
+  elif sys.platform == 'linux2' and target_arch in ('arm', 'ia32'):
+    # ARM build requires cross compilation.
     env['GYP_CROSSCOMPILE'] = '1'
 
+  # Always build on 64-bit machine.
+  gyp_defines += ' host_arch=x64'
+
   # Build 32-bit or 64-bit.
-  gyp_defines += ' ' + 'target_arch={0}'.format(target_arch)
+  gyp_defines += ' target_arch={0}'.format(target_arch)
   env['GYP_DEFINES'] = gyp_defines
 
   # Output directory.


### PR DESCRIPTION
This PR changes the way of building 32bit target from building in a chroot environment to cross-compilation, so we can have an uniform way of building for all targets on Linux.

The downside is setting up the Linux environment to build 32bit target would be very nasty.