### PR TITLE
Fix Windows build with static ffmpeg

### DIFF
--- a/patches/third_party/ffmpeg/ffmpeg.patch
+++ b/patches/third_party/ffmpeg/ffmpeg.patch
@@ -1,0 +1,34 @@
+diff --git a/ffmpeg.gyp b/ffmpeg.gyp
+index 07f229e..332ac44 100755
+--- a/ffmpeg.gyp
++++ b/ffmpeg.gyp
+@@ -431,14 +431,6 @@
+                     '_snprintf=avpriv_snprintf',
+                     'vsnprintf=avpriv_vsnprintf',
+                   ],
+-                }],
+-                ['target_arch == "x64"', {
+-                  # TODO(wolenetz): We should fix this.  http://crbug.com/171009
+-                  'msvs_disabled_warnings' : [
+-                    4267
+-                  ],
+-                }],
+-                ['ffmpeg_component == "shared_library"', {
+                   # Fix warnings about a local symbol being inefficiently imported.
+                   'msvs_settings': {
+                     'VCCLCompilerTool': {
+@@ -448,6 +440,14 @@
+                       ],
+                     },
+                   },
++                }],
++                ['target_arch == "x64"', {
++                  # TODO(wolenetz): We should fix this.  http://crbug.com/171009
++                  'msvs_disabled_warnings' : [
++                    4267
++                  ],
++                }],
++                ['ffmpeg_component == "shared_library"', {
+                   'sources': [
+                     '<(shared_generated_dir)/ffmpeg.def',
+                   ],


### PR DESCRIPTION
This patch is imported from https://codereview.qt-project.org/gitweb?p=qt/qtwebengine-chromium.git;a=commit;h=337abb1a5c73f76ffb8f989c5031cc7a908f472c.

> We need the include override everywhere the C99 methods are overriden otherwise MSVC ends up believing these to be external and look for their DLL hooks.