### PR TITLE
Add option to build local libchromiumcontent

### DIFF
--- a/script/download
+++ b/script/download
@@ -32,23 +32,48 @@ class ProgramError(Exception):
 def main():
   try:
     args = parse_args()
-    if args.commit == 'HEAD':
-      commit = head_commit()
+    if (args.libcc_source_path != None and
+        args.libcc_shared_library_path != None and
+        args.libcc_static_library_path != None):
+      if (not os.path.isdir(args.libcc_source_path)):
+        print "Error: Directory does not exist:", args.libcc_source_path
+        sys.exit(0)
+      elif (not os.path.isdir(args.libcc_shared_library_path)):
+        print "Error: Directory does not exist:", args.libcc_shared_library_path
+        sys.exit(0)
+      elif (not os.path.isdir(args.libcc_static_library_path)):
+        print "Error: Directory does not exist:", args.libcc_static_library_path
+        sys.exit(0)
+      generate_filenames_gypi(os.path.join(args.path, 'filenames.gypi'),
+                              args.libcc_source_path,
+                              args.libcc_shared_library_path,
+                              args.libcc_static_library_path)
+    elif (args.libcc_source_path != None or
+          args.libcc_shared_library_path != None or
+          args.libcc_static_library_path != None):
+      print "Error: All options of libchromiumcontent are required OR let libchromiumcontent choose it"
+      sys.exit(0)
     else:
-      commit = args.commit
-    if os.environ.has_key('MAS_BUILD'):
-      platform = 'mas'
-    else:
-      platform = PLATFORM_KEY
-    base_url = '{0}/{1}/{2}'.format(args.url, platform, args.target_arch)
-    download_if_needed(args.path, base_url, commit, SHARED_LIBRARY_FILENAME,
-                       args.force)
-    if (args.static and
-        not os.path.exists(os.path.join(args.path, 'static_library'))):
-      download(args.path, base_url, commit, STATIC_LIBRARY_FILENAME)
-    with open(os.path.join(args.path, '.target_arch'), 'w') as f:
-      f.write(args.target_arch)
-    generate_filenames_gypi(args.path)
+        if args.commit == 'HEAD':
+          commit = head_commit()
+        else:
+          commit = args.commit
+        if os.environ.has_key('MAS_BUILD'):
+          platform = 'mas'
+        else:
+          platform = PLATFORM_KEY
+        base_url = '{0}/{1}/{2}'.format(args.url, platform, args.target_arch)
+        download_if_needed(args.path, base_url, commit, SHARED_LIBRARY_FILENAME,
+                           args.force)
+        if (args.static and
+            not os.path.exists(os.path.join(args.path, 'static_library'))):
+          download(args.path, base_url, commit, STATIC_LIBRARY_FILENAME)
+        with open(os.path.join(args.path, '.target_arch'), 'w') as f:
+          f.write(args.target_arch)
+        generate_filenames_gypi(os.path.join(args.path, 'filenames.gypi'),
+                                os.path.join(args.path, 'src'),
+                                os.path.join(args.path, 'shared_library'),
+                                os.path.join(args.path, 'static_library'))
   except ProgramError as e:
     return e.message
 
@@ -67,6 +92,12 @@ def parse_args():
   parser.add_argument('url', help='The base URL from which to download '
                       '(i.e., the URL you passed to script/upload)')
   parser.add_argument('path', help='The path to extract to')
+  parser.add_argument('--libcc_source_path', required=False,
+                        help='The source path of libchromiumcontent. NOTE: All options of libchromiumcontent are required OR let libchromiumcontent choose it')
+  parser.add_argument('--libcc_shared_library_path', required=False,
+                        help='The shared library path of libchromiumcontent. NOTE: All options of libchromiumcontent are required OR let libchromiumcontent choose it')
+  parser.add_argument('--libcc_static_library_path', required=False,
+                        help='The static library path of libchromiumcontent. NOTE: All options of libchromiumcontent are required OR let libchromiumcontent choose it')
   return parser.parse_args()
 
 
@@ -135,13 +166,13 @@ def download_and_extract(destination, url):
       z.extractall(destination)
 
 
-def generate_filenames_gypi(destination):
+def generate_filenames_gypi(target_file, libcc_source_path,
+                            libcc_shared_library_path,
+                            libcc_static_library_path):
   generate = os.path.join(SOURCE_ROOT, 'tools', 'generate_filenames_gypi.py')
-  subprocess.check_call([sys.executable, generate,
-                         os.path.join(destination, 'filenames.gypi'),
-                         os.path.join(destination, 'shared_library'),
-                         os.path.join(destination, 'static_library')])
-
+  subprocess.check_call([sys.executable, generate] + [target_file,
+                         libcc_source_path, libcc_shared_library_path,
+                         libcc_static_library_path])
 
 def rm_rf(path):
   try:

--- a/tools/generate_filenames_gypi.py
+++ b/tools/generate_filenames_gypi.py
@@ -52,7 +52,9 @@ EXCLUDE_STATIC_LIBRARIES = {
 GYPI_TEMPLATE = """\
 {
   'variables': {
-    'libchromiumcontent_root_dir': %(src)s,
+    'libchromiumcontent_src_dir': %(src)s,
+    'libchromiumcontent_shared_libraries_dir': %(shared_libraries_dir)s,
+    'libchromiumcontent_static_libraries_dir': %(static_libraries_dir)s,
     'libchromiumcontent_shared_libraries': %(shared_libraries)s,
     'libchromiumcontent_shared_v8_libraries': %(shared_v8_libraries)s,
     'libchromiumcontent_static_libraries': %(static_libraries)s,
@@ -62,13 +64,15 @@ GYPI_TEMPLATE = """\
 """
 
 
-def main(target_file, shared_src, static_src):
+def main(target_file, code_dir, shared_dir, static_dir):
   (shared_libraries, shared_v8_libraries) = searh_files(
-      shared_src, SHARED_LIBRARY_SUFFIX, EXCLUDE_SHARED_LIBRARIES)
+      shared_dir, SHARED_LIBRARY_SUFFIX, EXCLUDE_SHARED_LIBRARIES)
   (static_libraries, static_v8_libraries) = searh_files(
-      static_src, STATIC_LIBRARY_SUFFIX, EXCLUDE_STATIC_LIBRARIES)
+      static_dir, STATIC_LIBRARY_SUFFIX, EXCLUDE_STATIC_LIBRARIES)
   content = GYPI_TEMPLATE % {
-    'src': repr(os.path.abspath(os.path.dirname(target_file))),
+    'src': repr(os.path.abspath(os.path.dirname(code_dir))),
+    'shared_libraries_dir': repr(os.path.abspath(os.path.dirname(shared_dir))),
+    'static_libraries_dir': repr(os.path.abspath(os.path.dirname(static_dir))),
     'shared_libraries': shared_libraries,
     'shared_v8_libraries': shared_v8_libraries,
     'static_libraries': static_libraries,
@@ -76,7 +80,6 @@ def main(target_file, shared_src, static_src):
   }
   with open(target_file, 'wb+') as f:
     f.write(content)
-
 
 def searh_files(src, suffix, exclude):
   files = glob.glob(os.path.join(src, '*.' + suffix))
@@ -91,4 +94,4 @@ def is_v8_library(p):
 
 
 if __name__ == '__main__':
-  sys.exit(main(sys.argv[1], sys.argv[2], sys.argv[3]))
+  sys.exit(main(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]))


### PR DESCRIPTION
- Currently libchromiumcontent is downloaded by default.
- Now developer can choose to provide local libchromiumcontent src, shared and static path

Tries to solve similar issue noted in: [https://github.com/atom/electron/issues/3310]