### PR TITLE
Move GPL causing flags to en environment variable check

### DIFF
--- a/chromiumcontent/chromiumcontent.gypi
+++ b/chromiumcontent/chromiumcontent.gypi
@@ -1,8 +1,5 @@
 {
   'variables': {
-    # Enalbe using proprietary codecs.
-    'proprietary_codecs': 1,
-    'ffmpeg_branding': 'Chrome',
     # Enable support for Widevine CDM.
     'enable_widevine': 1,
     # Using libc++ requires building for >= 10.7.

--- a/script/update
+++ b/script/update
@@ -135,6 +135,10 @@ def gyp_env(target_arch, component):
   else:
     gyp_defines += ' mac_mas_build=0'
 
+  # Enable using proprietary codecs.
+  if not env.has_key('NONGPL_BUILD'):
+    gyp_defines += ' proprietary_codecs=1 ffmpeg_branding=Chrome'
+
   # Always build on 64-bit machine.
   gyp_defines += ' host_arch=x64'
 


### PR DESCRIPTION
The flag `proprietary_codecs` causes the resulting build of `ffmpeg` to be GPL licensed.  Which in turn makes `chromium` GPL licensed and will then in turn make `electron` GPL.

This has been outlined in details here #178

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/atom/libchromiumcontent/179)
<!-- Reviewable:end -->
