### PR TITLE
Prevent capabilities from being dropped in renderer threads in Linux

### DIFF
--- a/patches/thread-capabilities.patch
+++ b/patches/thread-capabilities.patch
@@ -1,0 +1,13 @@
+diff --git a/sandbox/linux/services/credentials.cc b/sandbox/linux/services/credentials.cc
+index dd26472..6324ef5 100644
+--- a/sandbox/linux/services/credentials.cc
++++ b/sandbox/linux/services/credentials.cc
+@@ -324,8 +324,6 @@ pid_t Credentials::ForkAndDropCapabilitiesInChild() {
+     return pid;
+   }
+ 
+-  // Since we just forked, we are single threaded.
+-  PCHECK(DropAllCapabilitiesOnCurrentThread());
+   return 0;
+ }
+


### PR DESCRIPTION
Chromium automatically drops all capabilities of renderer threads in
Linux, which may cause issues in a context like Electron, where the main
and renderer threads are supposed to keep inherited permissions over the
system.

See https://github.com/atom/electron/issues/3666