### PR TITLE
Use GN instead of GYP to build Chromium sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /src/
 /libchromiumcontent.zip
 /libchromiumcontent-static.zip
+.gclient

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /libchromiumcontent.zip
 /libchromiumcontent-static.zip
 .gclient
+.gclient_entries

--- a/README.md
+++ b/README.md
@@ -16,14 +16,6 @@ dependencies (e.g., Blink, V8, etc.).
 
     $ script/bootstrap
 
-Assuming you have set up `depot_tools` according to the instructions above,
-checkout Chromium sources and switch to the correct version.
-
-    $ fetch chromium
-    $ cd src
-    $ git checkout $(cat ../VERSION)
-    $ gclient sync --with_branch_heads
-
 ### Building
 
     $ script/update -t x64

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ dependencies (e.g., Blink, V8, etc.).
 
     $ script/bootstrap
 
+Assuming you have set up `depot_tools` according to the instructions above,
+checkout Chromium sources and switch to the correct version.
+
+    $ fetch chromium
+    $ cd src
+    $ git checkout $(cat ../VERSION)
+    $ gclient sync --with_branch_heads
+
 ### Building
 
     $ script/update -t x64
@@ -23,14 +31,16 @@ dependencies (e.g., Blink, V8, etc.).
 
 ### Updating project files
 
-If you change `VERSION` to point to a different Chromium release, or modify
-`chromiumcontent.gyp{,i}`, you should run:
+If you switch to a different Chromium release, or modify
+files inside the `chromiumcontent` directory, you should run:
 
     $ script/update
 
 This will regenerate all the project files. Then you can build again.
 
 ### Building for ARM target
+
+> TODO: This section may be out of date, needs review
 
 ```bash
 $ ./script/bootstrap

--- a/chromiumcontent/BUILD.gn
+++ b/chromiumcontent/BUILD.gn
@@ -35,6 +35,29 @@ group("targets") {
       "//ui/views",
       "//ui/views/controls/webview",
     ]
+
+    if (is_component_build) {
+      deps += [
+        ":desktop_capture",
+        ":devtools_discovery",
+        ":devtools_http_handler",
+        ":fx_agg",
+        ":fx_lcms2",
+        ":fx_libopenjpeg",
+        ":fx_zlib",
+        ":libjpeg",
+        ":libyuv",
+        ":ppapi_cpp_objects",
+        ":ppapi_internal_module",
+        ":security_state",
+        ":system_wrappers",
+        ":webrtc_common",
+      ]
+
+      if (is_win) {
+        deps += [ ":sandbox_helper_win" ]
+      }
+    }
   }
 
   # These produce executables we distribute as part of libchromiumcontent.
@@ -51,6 +74,85 @@ group("targets") {
   # We build FFMPEG separately in the default non-component configuration
   if (!is_electron_build && !is_component_build) {
     deps += [ "//third_party/ffmpeg" ]
+  }
+}
+
+if (is_electron_build && is_component_build) {
+  static_library("desktop_capture") {
+      complete_static_lib = true
+      deps = [ "//third_party/webrtc/modules/desktop_capture" ]
+  }
+
+  static_library("devtools_discovery") {
+      complete_static_lib = true
+      deps = [ "//components/devtools_discovery" ]
+  }
+
+  static_library("devtools_http_handler") {
+      complete_static_lib = true
+      deps = [ "//components/devtools_http_handler" ]
+  }
+
+  static_library("fx_agg") {
+      complete_static_lib = true
+      deps = [ "//third_party/pdfium/third_party:fx_agg" ]
+  }
+
+  static_library("fx_lcms2") {
+      complete_static_lib = true
+      deps = [ "//third_party/pdfium/third_party:fx_lcms2" ]
+  }
+
+  static_library("fx_libopenjpeg") {
+      complete_static_lib = true
+      deps = [ "//third_party/pdfium/third_party:fx_libopenjpeg" ]
+  }
+
+  static_library("fx_zlib") {
+      complete_static_lib = true
+      deps = [ "//third_party/pdfium/third_party:fx_zlib" ]
+  }
+
+  static_library("libjpeg") {
+      complete_static_lib = true
+      deps = [ "//third_party:jpeg" ]
+  }
+
+  static_library("libyuv") {
+      complete_static_lib = true
+      deps = [ "//third_party/libyuv" ]
+  }
+
+  static_library("ppapi_cpp_objects") {
+      complete_static_lib = true
+      deps = [ "//ppapi/cpp:objects" ]
+  }
+
+  static_library("ppapi_internal_module") {
+      complete_static_lib = true
+      deps = [ "//ppapi/cpp/private:internal_module" ]
+  }
+
+  static_library("security_state") {
+      complete_static_lib = true
+      deps = [ "//components/security_state" ]
+  }
+
+  static_library("system_wrappers") {
+      complete_static_lib = true
+      deps = [ "//third_party/webrtc/system_wrappers" ]
+  }
+
+  static_library("webrtc_common") {
+      complete_static_lib = true
+      deps = [ "//third_party/webrtc:webrtc_common" ]
+  }
+
+  if (is_win) {
+    static_library("sandbox_helper_win") {
+      complete_static_lib = true
+      deps = [ "//content:sandbox_helper_win" ]
+    }
   }
 }
 

--- a/chromiumcontent/BUILD.gn
+++ b/chromiumcontent/BUILD.gn
@@ -1,0 +1,213 @@
+declare_args() {
+  is_electron_build = false
+}
+
+group("targets") {
+  deps = []
+
+  # Build these targets when building libchromiumcontent's
+  # "static_library" or "shared_library"
+  if (is_electron_build) {
+    deps += [
+      "//components/prefs",
+      "//components/cdm/renderer",
+      "//components/cookie_config",
+      "//components/devtools_discovery",
+      "//components/devtools_http_handler",
+      "//components/security_state",
+      "//content",
+      "//content:sandbox_helper_win",
+      "//content/public/app:both",
+      "//content/shell:pak",
+      "//content/shell:copy_shell_resources",
+      "//pdf",
+      "//ppapi:ppapi_cpp_lib",
+      "//ppapi/host",
+      "//ppapi/proxy",
+      "//ppapi/shared_impl",
+      "//net:net_with_v8",
+      "//third_party/webrtc/modules/desktop_capture",
+      "//third_party/widevine/cdm:widevinecdmadapter",
+      "//third_party/widevine/cdm:version_h",
+      "//ui/content_accelerators",
+      "//ui/display",
+      "//ui/display/util",
+      "//ui/views",
+      "//ui/views/controls/webview",
+    ]
+  }
+
+  # These produce executables we distribute as part of libchromiumcontent.
+  # Statically linked versions of them are built correctly only when the build
+  # configuration is not tweaked for the purposes of statically linked
+  # Electron.
+  if (!is_electron_build || is_component_build) {
+    deps += [
+      "//chrome/test/chromedriver",
+      "//v8",
+    ]
+  }
+
+  # We build FFMPEG separately in the default non-component configuration
+  if (!is_electron_build && !is_component_build) {
+    deps += [ "//third_party/ffmpeg" ]
+  }
+}
+
+if (is_electron_build && !is_component_build) {
+
+  # This is where we build statically linked libchromiumcontent.
+  # After all dependent targets are built, we use a script to collect
+  # all required object files into an "objects.gni" file and re-run
+  # ninja. Because "objects.gni" is a GN input file, it will cause it
+  # to re-generate the targets and produce the static libraries we want.
+
+  # Make sure the .gni file exists, otherwise it cannot be imported
+  if (getenv("CHROMIUMCONTENT_2ND_PASS") == "") {
+    write_file("$target_out_dir/objects.gni", "")
+  }
+
+  import("$target_out_dir/objects.gni")
+
+  action("chromiumcontent") {
+    outputs = [ "$target_out_dir/build_libs.done" ]
+
+    script = "build_libs.py"
+    args = [ "-o", rebase_path("$target_out_dir/objects.gni"),
+             "-s", rebase_path(outputs[0]) ]
+
+    deps = [ ":targets" ]
+  }
+
+  # Due to various limitations of different toolchains (like maximum
+  # lib file size or maximum number of obj files), we produce multiple
+  # static libraries
+  group("libs") {
+    deps = [
+      ":libchromiumcontent",
+      ":base",
+      ":cc",
+      ":components",
+      ":ppapi",
+      ":media",
+      ":net",
+      ":skia",
+      ":angle",
+      ":pdfium",
+      ":webkit",
+      ":webrtc",
+      ":v8",
+    ]
+  }
+
+  static_library("libchromiumcontent") {
+    complete_static_lib = true
+    sources = []
+    if (defined(obj_libchromiumcontent)) {
+      sources += obj_libchromiumcontent
+    }
+  }
+
+  static_library("base") {
+    complete_static_lib = true
+    sources = []
+    if (defined(obj_base)) {
+      sources += obj_base
+    }
+  }
+
+  static_library("cc") {
+    complete_static_lib = true
+    sources = []
+    if (defined(obj_cc)) {
+      sources += obj_cc
+    }
+  }
+
+  static_library("components") {
+    complete_static_lib = true
+    sources = []
+    if (defined(obj_components)) {
+      sources += obj_components
+    }
+  }
+
+  static_library("ppapi") {
+    complete_static_lib = true
+    sources = []
+    if (defined(obj_ppapi)) {
+      sources += obj_ppapi
+    }
+  }
+
+  static_library("media") {
+    complete_static_lib = true
+    sources = []
+    if (defined(obj_media)) {
+      sources += obj_media
+    }
+  }
+
+  static_library("net") {
+    complete_static_lib = true
+    sources = []
+    if (defined(obj_net)) {
+      sources += obj_net
+    }
+  }
+
+  static_library("skia") {
+    complete_static_lib = true
+    sources = []
+    if (defined(obj_skia)) {
+      sources += obj_skia
+    }
+  }
+
+  static_library("angle") {
+    complete_static_lib = true
+    sources = []
+    if (defined(obj_angle)) {
+      sources += obj_angle
+    }
+  }
+
+  static_library("pdfium") {
+    complete_static_lib = true
+    sources = []
+    if (defined(obj_pdfium)) {
+      sources += obj_pdfium
+    }
+  }
+
+  static_library("webkit") {
+    complete_static_lib = true
+    sources = []
+    if (defined(obj_webkit)) {
+      sources += obj_webkit
+    }
+  }
+
+  static_library("webrtc") {
+    complete_static_lib = true
+    sources = []
+    if (defined(obj_webrtc)) {
+      sources += obj_webrtc
+    }
+  }
+
+  static_library("v8") {
+    complete_static_lib = true
+    sources = []
+    if (defined(obj_v8)) {
+      sources += obj_v8
+    }
+  }
+
+} else {
+
+  group("chromiumcontent") {
+    deps = [ ":targets" ]
+  }
+
+}

--- a/chromiumcontent/BUILD.gn
+++ b/chromiumcontent/BUILD.gn
@@ -36,6 +36,10 @@ group("targets") {
       "//ui/views/controls/webview",
     ]
 
+    if (is_linux) {
+      deps += [ "//chrome/browser/ui/libgtk2ui" ]
+    }
+
     if (is_component_build) {
       deps += [
         ":desktop_capture",
@@ -53,6 +57,10 @@ group("targets") {
         ":system_wrappers",
         ":webrtc_common",
       ]
+
+      if (is_linux) {
+        deps += [ ":libgtk2ui" ]
+      }
 
       if (is_win) {
         deps += [ ":sandbox_helper_win" ]
@@ -146,6 +154,21 @@ if (is_electron_build && is_component_build) {
   static_library("webrtc_common") {
       complete_static_lib = true
       deps = [ "//third_party/webrtc:webrtc_common" ]
+  }
+
+  if (is_linux) {
+    static_library("libgtk2ui") {
+      complete_static_lib = true
+      sources = [
+        "$root_out_dir/obj/chrome/browser/ui/libgtk2ui/libgtk2ui/app_indicator_icon.o",
+        "$root_out_dir/obj/chrome/browser/ui/libgtk2ui/libgtk2ui/app_indicator_icon_menu.o",
+        "$root_out_dir/obj/chrome/browser/ui/libgtk2ui/libgtk2ui/gtk2_util.o",
+        "$root_out_dir/obj/chrome/browser/ui/libgtk2ui/libgtk2ui/gtk2_status_icon.o",
+        "$root_out_dir/obj/chrome/browser/ui/libgtk2ui/libgtk2ui/menu_util.o",
+        "$root_out_dir/obj/chrome/browser/ui/libgtk2ui/libgtk2ui/skia_utils_gtk2.o",
+        "$root_out_dir/obj/chrome/browser/ui/libgtk2ui/libgtk2ui/unity_service.o",
+      ]
+    }
   }
 
   if (is_win) {
@@ -312,4 +335,21 @@ if (is_electron_build && !is_component_build) {
     deps = [ ":targets" ]
   }
 
+}
+
+# There are some executable targets whose products are ran during build.
+# This config is applied to those targets because we need to give them some
+# special treatment.
+config("build_time_executable") {
+  configs = []
+
+  # The executables which have this config applied are dependent on ICU,
+  # which is always a shared library in an Electron build. However, in the
+  # non-component build, Linux executables don't have rpath set to search for
+  # libraries in the executable's directory, so ICU cannot be found. So let's
+  # make sure rpath is set here.
+  # See '//build/config/gcc/BUILD.gn' for details on the rpath setting.
+  if (is_electron_build && is_linux && !is_component_build) {
+    configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
+  }
 }

--- a/chromiumcontent/BUILD.gn
+++ b/chromiumcontent/BUILD.gn
@@ -86,6 +86,12 @@ group("targets") {
 }
 
 if (is_electron_build && is_component_build) {
+
+  # Electron needs some APIs which are not exported from shared libraries
+  # produced by a component build. So we put a copy of the needed symbols in
+  # this set of static libraries. Most can just depend on the respective
+  # source_set target.
+
   static_library("desktop_capture") {
       complete_static_lib = true
       deps = [ "//third_party/webrtc/modules/desktop_capture" ]
@@ -157,6 +163,8 @@ if (is_electron_build && is_component_build) {
   }
 
   if (is_linux) {
+    # The original libgtk2ui target is a shared library, so we must list
+    # the object files instead of just depending on it.
     static_library("libgtk2ui") {
       complete_static_lib = true
       sources = [
@@ -204,9 +212,10 @@ if (is_electron_build && !is_component_build) {
     deps = [ ":targets" ]
   }
 
-  # Due to various limitations of different toolchains (like maximum
-  # lib file size or maximum number of obj files), we produce multiple
-  # static libraries
+  # Normally we would just put everything in a single library plus V8. But
+  # toolchains have various limitations that we would hit - e.g. MSVC cannot
+  # produce a .lib file bigger than 4 GB, LLVM has a limit on the number of
+  # object files on the command line. So we produce multiple libraries.
   group("libs") {
     deps = [
       ":libchromiumcontent",

--- a/chromiumcontent/args/ffmpeg.gn
+++ b/chromiumcontent/args/ffmpeg.gn
@@ -1,0 +1,8 @@
+root_extra_deps = [ "//chromiumcontent:chromiumcontent" ]
+is_component_build = false
+is_debug = false
+enable_nacl = false
+enable_widevine = true
+proprietary_codecs = false
+is_component_ffmpeg = true
+ffmpeg_branding = "Chromium"

--- a/chromiumcontent/args/shared_library.gn
+++ b/chromiumcontent/args/shared_library.gn
@@ -1,0 +1,9 @@
+root_extra_deps = [ "//chromiumcontent:chromiumcontent" ]
+is_electron_build = true
+is_component_build = true
+is_debug = false
+enable_nacl = false
+enable_widevine = true
+proprietary_codecs = true
+is_component_ffmpeg = true
+ffmpeg_branding = "Chrome"

--- a/chromiumcontent/args/static_library.gn
+++ b/chromiumcontent/args/static_library.gn
@@ -1,0 +1,9 @@
+root_extra_deps = [ "//chromiumcontent:chromiumcontent" ]
+is_electron_build = true
+is_component_build = false
+is_debug = false
+enable_nacl = false
+enable_widevine = true
+proprietary_codecs = true
+is_component_ffmpeg = true
+ffmpeg_branding = "Chrome"

--- a/chromiumcontent/build_libs.py
+++ b/chromiumcontent/build_libs.py
@@ -1,0 +1,229 @@
+import argparse
+import os
+import subprocess
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-o', dest='out')
+parser.add_argument('-s', dest='stamp')
+args = parser.parse_args()
+
+def gen_list(out, name, obj_dirs):
+    out.write(name + " = [\n")
+    for base_dir in obj_dirs:
+        for dir, subdirs, files in os.walk(os.path.join('obj', base_dir)):
+            for f in files:
+                if f.endswith('.obj') or f.endswith('.o'):
+                    out.write('"' + os.path.abspath(os.path.join(dir, f)) + '",\n')
+    out.write("]\n")
+
+with open(args.out, 'w') as out:
+    gen_list(
+        out,
+        "obj_libchromiumcontent",
+        [
+            "content",
+            "crypto",
+            "device",
+            "gin",
+            "google_apis",
+            "gpu",
+            "ipc",
+            "jingle",
+            "mojo",
+            "pdf",
+            "printing",
+            "sandbox",
+            "sdch",
+            "services/catalog",
+            "services/shell/public",
+            "services/shell/runner",
+            "services/shell/shell",
+            "services/tracing/public",
+            "services/user",
+            "sql/sql",
+            "storage",
+            "third_party/adobe",
+            "third_party/boringssl",
+            "third_party/brotli",
+            "third_party/decklink",
+            "third_party/expat",
+            "third_party/ffmpeg",
+            "third_party/flac",
+            "third_party/harfbuzz-ng",
+            "third_party/iaccessible2",
+            "third_party/iccjpeg",
+            "third_party/isimpledom",
+            "third_party/leveldatabase",
+            "third_party/libjingle",
+            "third_party/libjpeg_turbo",
+            "third_party/libpng",
+            "third_party/libsrtp",
+            "third_party/libusb",
+            "third_party/libvpx",
+            "third_party/libwebm",
+            "third_party/libwebp",
+            "third_party/libxml",
+            "third_party/libxslt",
+            "third_party/libyuv",
+            "third_party/mesa",
+            "third_party/modp_b64",
+            "third_party/mozilla",
+            "third_party/openh264",
+            "third_party/openmax_dl",
+            "third_party/opus",
+            "third_party/ots",
+            "third_party/protobuf/protobuf_lite",
+            "third_party/qcms",
+            "third_party/re2",
+            "third_party/sfntly",
+            "third_party/smhasher",
+            "third_party/snappy",
+            "third_party/sqlite",
+            "third_party/sudden_motion_sensor",
+            "third_party/usrsctp",
+            "third_party/widevine/cdm/widevinecdm",
+            "third_party/woff2",
+            "third_party/zlib",
+            "tools",
+            "ui",
+            "url",
+        ])
+
+    gen_list(
+        out,
+        "obj_base",
+        [
+            "base/base",
+            "base/base_paths",
+            "base/base_static",
+            "base/build_utf8_validator_tables",
+            "base/i18n",
+            "base/third_party",
+        ])
+
+    gen_list(
+        out,
+        "obj_cc",
+        [
+            "cc/base",
+            "cc/blink",
+            "cc/cc",
+            "cc/ipc",
+            "cc/proto",
+            "cc/surfaces",
+        ])
+
+    gen_list(
+        out,
+        "obj_components",
+        [
+            "components/bitmap_uploader",
+            "components/cdm",
+            "components/cookie_config",
+            "components/devtools_discovery",
+            "components/devtools_http_handler",
+            "components/display_compositor",
+            "components/filesystem",
+            "components/leveldb",
+            "components/link_header_util",
+            "components/mime_util",
+            "components/mus/clipboard",
+            "components/mus/common",
+            "components/mus/gles2",
+            "components/mus/gpu",
+            "components/mus/input_devices",
+            "components/mus/public",
+            "components/os_crypt",
+            "components/prefs",
+            "components/scheduler/common",
+            "components/scheduler/scheduler",
+            "components/security_state",
+            "components/tracing",
+            "components/url_formatter",
+            "components/webcrypto",
+            "components/webmessaging",
+        ])
+
+    gen_list(
+        out,
+        "obj_ppapi",
+        [
+            "ppapi/cpp/objects",
+            "ppapi/cpp/private",
+            "ppapi/host",
+            "ppapi/proxy",
+            "ppapi/shared_impl",
+            "ppapi/thunk",
+        ])
+
+    gen_list(
+        out,
+        "obj_media",
+        [
+            "media",
+        ])
+
+    gen_list(
+        out,
+        "obj_net",
+        [
+            "net",
+        ])
+
+    gen_list(
+        out,
+        "obj_skia",
+        [
+            "skia",
+        ])
+
+    gen_list(
+        out,
+        "obj_angle",
+        [
+            "third_party/angle/angle_common",
+            "third_party/angle/libANGLE",
+            "third_party/angle/libEGL",
+            "third_party/angle/libGLESv2",
+            "third_party/angle/preprocessor",
+            "third_party/angle/translator",
+            "third_party/angle/translator_lib",
+        ])
+
+    gen_list(
+        out,
+        "obj_pdfium",
+        [
+            "third_party/pdfium",
+        ])
+
+    gen_list(
+        out,
+        "obj_webkit",
+        [
+            "third_party/WebKit",
+        ])
+
+    gen_list(
+        out,
+        "obj_webrtc",
+        [
+            "third_party/webrtc",
+        ])
+
+    gen_list(
+        out,
+        "obj_v8",
+        [
+            "v8/v8_base",
+            "v8/v8_external_snapshot",
+            "v8/v8_libbase",
+            "v8/v8_libplatform",
+            "v8/v8_libsampler",
+            "third_party/icu",
+        ])
+
+os.environ['CHROMIUMCONTENT_2ND_PASS'] = '1'
+subprocess.check_call(['ninja', 'chromiumcontent:libs'])
+
+open(args.stamp, 'w')

--- a/chromiumcontent/build_libs.py
+++ b/chromiumcontent/build_libs.py
@@ -21,8 +21,11 @@ with open(args.out, 'w') as out:
         out,
         "obj_libchromiumcontent",
         [
+            "build",
+            "chrome/browser/ui/libgtk2ui",
             "content",
             "crypto",
+            "dbus",
             "device",
             "gin",
             "google_apis",
@@ -44,7 +47,7 @@ with open(args.out, 'w') as out:
             "storage",
             "third_party/adobe",
             "third_party/boringssl",
-            "third_party/brotli",
+            "third_party/brotli/brotli",
             "third_party/decklink",
             "third_party/expat",
             "third_party/ffmpeg",
@@ -54,6 +57,7 @@ with open(args.out, 'w') as out:
             "third_party/iccjpeg",
             "third_party/isimpledom",
             "third_party/leveldatabase",
+            "third_party/libXNVCtrl",
             "third_party/libjingle",
             "third_party/libjpeg_turbo",
             "third_party/libpng",
@@ -93,6 +97,7 @@ with open(args.out, 'w') as out:
         out,
         "obj_base",
         [
+            "base/allocator",
             "base/base",
             "base/base_paths",
             "base/base_static",
@@ -201,7 +206,14 @@ with open(args.out, 'w') as out:
         out,
         "obj_webkit",
         [
-            "third_party/WebKit",
+            "third_party/WebKit/public",
+            "third_party/WebKit/Source/platform/heap",
+            "third_party/WebKit/Source/platform/blink_common",
+            "third_party/WebKit/Source/platform/platform",
+            "third_party/WebKit/Source/web",
+            "third_party/WebKit/Source/core",
+            "third_party/WebKit/Source/wtf",
+            "third_party/WebKit/Source/modules",
         ])
 
     gen_list(

--- a/chromiumcontent/config.gni
+++ b/chromiumcontent/config.gni
@@ -1,0 +1,18 @@
+if (!defined(is_electron_build)) {
+  is_electron_build = false
+}
+
+if (is_electron_build) {
+  component_electron = "shared_library"
+} else {
+  # Due to a bug in how GN applies defaults to template targets invoked
+  # via the "target" function, we cannot fall back to the "component" template.
+  #
+  # component_electron = "component"
+
+  if (is_component_build) {
+    component_electron = "shared_library"
+  } else {
+    component_electron = "source_set"
+  }
+}

--- a/patches/build_gn.patch
+++ b/patches/build_gn.patch
@@ -19,3 +19,15 @@ index e5fdb29e858f..01b6973cb494 100644
        ldflags = [
          # Not to strip important symbols by -Wl,-dead_strip.
          "-Wl,-exported_symbol,_PPP_GetInterface",
+diff --git a/third_party/WebKit/Source/platform/BUILD.gn b/third_party/WebKit/Source/platform/BUILD.gn
+index 631aa54..84422a3 100644
+--- a/third_party/WebKit/Source/platform/BUILD.gn
++++ b/third_party/WebKit/Source/platform/BUILD.gn
+@@ -172,6 +172,7 @@ action("character_data") {
+ }
+ 
+ executable("character_data_generator") {
++  configs += [ "//chromiumcontent:build_time_executable" ]
+   sources = [
+     "text/CharacterPropertyDataGenerator.cpp",
+     "text/CharacterPropertyDataGenerator.h",

--- a/patches/build_gn.patch
+++ b/patches/build_gn.patch
@@ -1,0 +1,21 @@
+diff --git a/third_party/widevine/cdm/BUILD.gn b/third_party/widevine/cdm/BUILD.gn
+index e5fdb29e858f..01b6973cb494 100644
+--- a/third_party/widevine/cdm/BUILD.gn
++++ b/third_party/widevine/cdm/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//chromiumcontent/config.gni")
+ import("//build/config/chrome_build.gni")
+ import("//build/config/features.gni")
+ import("//chrome/version.gni")  # TODO layering violation
+@@ -93,7 +94,7 @@ if (widevine_cdm_binary_files != []) {
+       "//build/config/sanitizers:deps",
+     ]
+ 
+-    if (is_mac) {
++    if (is_mac && !is_electron_build) {
+       ldflags = [
+         # Not to strip important symbols by -Wl,-dead_strip.
+         "-Wl,-exported_symbol,_PPP_GetInterface",

--- a/patches/third_party/ffmpeg/build_gn.patch
+++ b/patches/third_party/ffmpeg/build_gn.patch
@@ -1,0 +1,18 @@
+diff --git a/BUILD.gn b/BUILD.gn
+index 3de144958d..83d9080d0b 100755
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -356,6 +356,13 @@ if (is_component_ffmpeg) {
+     # So we can append below and assume they're defined.
+     ldflags = []
+ 
++    # Chromium's Mac toolchain sets the "install_name" linker parameter only
++    # when "is_component_build" is true, but we want to set even if it's false,
++    # because we are making a dylib which will be distributed inside a bundle.
++    if (!is_component_build && is_mac) {
++      ldflags += [ "-Wl,-install_name,@rpath/libffmpeg.dylib" ]
++    }
++
+     if (is_posix && !is_mac) {
+       # Fixes warnings PIC relocation when building as component.
+       ldflags += [

--- a/patches/third_party/icu/build_gn.patch
+++ b/patches/third_party/icu/build_gn.patch
@@ -1,0 +1,59 @@
+diff --git a/BUILD.gn b/BUILD.gn
+index f3767c56..264888f0 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//chromiumcontent/config.gni")
+ import("//third_party/icu/config.gni")
+ 
+ if (is_android) {
+@@ -34,7 +35,7 @@ config("icu_config") {
+     "U_NOEXCEPT=",
+   ]
+ 
+-  if (!is_component_build) {
++  if (!is_component_build && !is_electron_build) {
+     defines += [ "U_STATIC_IMPLEMENTATION" ]
+   }
+ 
+@@ -120,7 +121,7 @@ config("icu_code") {
+   }
+ }
+ 
+-component("icui18n") {
++target(component_electron, "icui18n") {
+   # find  source/i18n -maxdepth 1  ! -type d  | egrep  '\.(c|cpp)$' |\
+   # sort | sed 's/^\(.*\)$/    "\1",/'
+   sources = [
+@@ -325,6 +326,9 @@ component("icui18n") {
+     "source/i18n/ztrans.cpp",
+   ]
+   defines = [ "U_I18N_IMPLEMENTATION" ]
++  if (is_electron_build) {
++    defines += [ "U_COMBINED_IMPLEMENTATION" ]
++  }
+   deps = [
+     ":icuuc",
+   ]
+@@ -351,7 +355,7 @@ component("icui18n") {
+   }
+ }
+ 
+-component("icuuc") {
++target(component_electron, "icuuc") {
+   # find  source/common -maxdepth 1  ! -type d  | egrep  '\.(c|cpp)$' |\
+   # sort | sed 's/^\(.*\)$/    "\1",/'
+   sources = [
+@@ -537,6 +541,9 @@ component("icuuc") {
+     "source/common/wintz.c",
+   ]
+   defines = [ "U_COMMON_IMPLEMENTATION" ]
++  if (is_electron_build) {
++    defines += [ "U_COMBINED_IMPLEMENTATION" ]
++  }
+   deps = [
+     ":icudata",
+   ]

--- a/patches/v8/build_gn.patch
+++ b/patches/v8/build_gn.patch
@@ -1,5 +1,5 @@
 diff --git a/BUILD.gn b/BUILD.gn
-index 3121dceccf..a99e757b2c 100644
+index 3121dce..22a6d02 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
 @@ -2,6 +2,7 @@
@@ -28,7 +28,15 @@ index 3121dceccf..a99e757b2c 100644
      defines = [
        "V8_SHARED",
        "USING_V8_SHARED",
-@@ -2091,7 +2092,7 @@ group("gn_all") {
+@@ -2044,6 +2045,7 @@ if (current_toolchain == v8_snapshot_toolchain) {
+     ]
+ 
+     configs = [ ":internal_config" ]
++    configs += [ "//chromiumcontent:build_time_executable" ]
+ 
+     deps = [
+       ":v8_base",
+@@ -2091,7 +2093,7 @@ group("gn_all") {
    }
  }
  
@@ -38,7 +46,7 @@ index 3121dceccf..a99e757b2c 100644
      sources = [
        "src/v8dll-main.cc",
 diff --git a/gni/v8.gni b/gni/v8.gni
-index 24f65679a4..8b91eed7dc 100644
+index 24f6567..8b91eed 100644
 --- a/gni/v8.gni
 +++ b/gni/v8.gni
 @@ -2,6 +2,7 @@

--- a/patches/v8/build_gn.patch
+++ b/patches/v8/build_gn.patch
@@ -1,0 +1,60 @@
+diff --git a/BUILD.gn b/BUILD.gn
+index 3121dceccf..a99e757b2c 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//chromiumcontent/config.gni")
+ import("//build/config/android/config.gni")
+ import("//build/config/arm.gni")
+ import("//build/config/dcheck_always_on.gni")
+@@ -74,7 +75,7 @@ config("internal_config") {
+ 
+   include_dirs = [ "." ]
+ 
+-  if (is_component_build) {
++  if (is_component_build || is_electron_build) {
+     defines = [
+       "V8_SHARED",
+       "BUILDING_V8_SHARED",
+@@ -101,7 +102,7 @@ config("libsampler_config") {
+ # This config should only be applied to code using V8 and not any V8 code
+ # itself.
+ config("external_config") {
+-  if (is_component_build) {
++  if (is_component_build || is_electron_build) {
+     defines = [
+       "V8_SHARED",
+       "USING_V8_SHARED",
+@@ -2091,7 +2092,7 @@ group("gn_all") {
+   }
+ }
+ 
+-if (is_component_build) {
++if (is_component_build || is_electron_build) {
+   v8_component("v8") {
+     sources = [
+       "src/v8dll-main.cc",
+diff --git a/gni/v8.gni b/gni/v8.gni
+index 24f65679a4..8b91eed7dc 100644
+--- a/gni/v8.gni
++++ b/gni/v8.gni
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//chromiumcontent/config.gni")
+ import("//build/config/v8_target_cpu.gni")
+ import("//build/config/sanitizers/sanitizers.gni")
+ 
+@@ -70,7 +71,7 @@ template("v8_executable") {
+ }
+ 
+ template("v8_component") {
+-  component(target_name) {
++  target(component_electron, target_name) {
+     forward_variables_from(invoker, "*", [ "configs" ])
+     configs += invoker.configs
+     configs -= remove_configs

--- a/script/build
+++ b/script/build
@@ -22,6 +22,12 @@ def main():
   args = parse_args()
   target_arch = args.target_arch
 
+  env = os.environ.copy()
+  env['PATH'] = os.pathsep.join([os.path.join(VENDOR_DIR, 'depot_tools'),
+                                 env['PATH']])
+  if sys.platform in ['win32', 'cygwin']:
+    env['DEPOT_TOOLS_WIN_TOOLCHAIN'] = '0'
+
   os.chdir(SOURCE_ROOT)
 
   for component in COMPONENTS:
@@ -32,10 +38,8 @@ def main():
                              get_output_dir(target_arch, component))
       config = get_configuration(target_arch)
       config_dir = os.path.relpath(os.path.join(out_dir, config))
-      target = 'chromiumcontent_all'
-      if component == 'ffmpeg':
-        target = 'ffmpeg'
-      subprocess.check_call([NINJA, '-C', config_dir, target])
+      target = 'chromiumcontent:chromiumcontent'
+      subprocess.check_call([NINJA, '-C', config_dir, target], env=env)
 
 
 def parse_args():

--- a/script/create-dist
+++ b/script/create-dist
@@ -56,24 +56,10 @@ BINARIES = {
     os.path.join('gen', 'ui', 'views', 'resources', 'views_resources_300_percent.pak'),
   ],
   'darwin': [
-    'chromedriver',
-    'mksnapshot',
+# TODO: Take these from the "ffmpeg" output directory
+#    'chromedriver',
+#    'mksnapshot',
     'libffmpeg.dylib',
-    'libdevtools_discovery.a',
-    'libdevtools_http_handler.a',
-    'libhttp_server.a',
-    'libdesktop_capture.a',
-    'libdesktop_capture_differ_sse2.a',
-    'librtc_base.a',
-    'librtc_base_approved.a',
-    'libwebrtc_common.a',
-    'libyuv.a',
-    'libsystem_wrappers.a',
-    'libcdm_renderer.a',
-    'libsecurity_state.a',
-    'libcookie_config.a',
-    'libos_crypt.a',
-    'libdom_keycode_converter.a',
   ],
   'linux': [
     'chromedriver',
@@ -98,96 +84,15 @@ BINARIES = {
     os.path.join('lib', 'libffmpeg.so'),
   ],
   'win32': [
-    'chromedriver.exe',
+# TODO: Take these from the "ffmpeg" output directory
+#    'chromedriver.exe',
+#    'mksnapshot.exe',
     'd3dcompiler_47.dll',
     'ffmpeg.dll',
     'ffmpeg.dll.lib',
     'libEGL.dll',
     'libGLESv2.dll',
-    'libyuv.lib',
-    'mksnapshot.exe',
     os.path.join('gen', 'ui', 'resources', 'ui_unscaled_resources.rc'),
-    os.path.join('obj', 'base', 'base_static.cc.pdb'),
-    os.path.join('obj', 'base', 'base_static.lib'),
-    os.path.join('obj', 'components', 'devtools_discovery.cc.pdb'),
-    os.path.join('obj', 'components', 'devtools_discovery.lib'),
-    os.path.join('obj', 'components', 'devtools_http_handler.cc.pdb'),
-    os.path.join('obj', 'components', 'devtools_http_handler.lib'),
-    os.path.join('obj', 'components', 'cdm_renderer.cc.pdb'),
-    os.path.join('obj', 'components', 'cdm_renderer.lib'),
-    os.path.join('obj', 'components', 'cookie_config.cc.pdb'),
-    os.path.join('obj', 'components', 'cookie_config.lib'),
-    os.path.join('obj', 'components', 'os_crypt.cc.pdb'),
-    os.path.join('obj', 'components', 'os_crypt.lib'),
-    os.path.join('obj', 'components', 'security_state.cc.pdb'),
-    os.path.join('obj', 'components', 'security_state.lib'),
-    os.path.join('obj', 'content', 'sandbox_helper_win.cc.pdb'),
-    os.path.join('obj', 'content', 'sandbox_helper_win.lib'),
-    os.path.join('obj', 'net', 'http_server.cc.pdb'),
-    os.path.join('obj', 'net', 'http_server.lib'),
-    os.path.join('obj', 'pdf', 'pdf.cc.pdb'),
-    os.path.join('obj', 'pdf', 'pdf.lib'),
-    os.path.join('obj', 'ppapi', 'ppapi_cpp_objects.cc.pdb'),
-    os.path.join('obj', 'ppapi', 'ppapi_cpp_objects.lib'),
-    os.path.join('obj', 'ppapi', 'ppapi_cpp.cc.pdb'),
-    os.path.join('obj', 'ppapi', 'ppapi_cpp.lib'),
-    os.path.join('obj', 'ppapi', 'ppapi_internal_module.cc.pdb'),
-    os.path.join('obj', 'ppapi', 'ppapi_internal_module.lib'),
-    os.path.join('obj', 'sandbox', 'sandbox.cc.pdb'),
-    os.path.join('obj', 'sandbox', 'sandbox.lib'),
-    os.path.join('obj', 'third_party', 'libjpeg_turbo', 'libjpeg.c.pdb'),
-    os.path.join('obj', 'third_party', 'libjpeg_turbo', 'libjpeg.lib'),
-    os.path.join('obj', 'third_party', 'libyuv', 'libyuv.cc.pdb'),
-    os.path.join('obj', 'third_party', 'pdfium', 'pdfium.cc.pdb'),
-    os.path.join('obj', 'third_party', 'pdfium', 'pdfium.lib'),
-    os.path.join('obj', 'third_party', 'pdfium', 'fdrm.cc.pdb'),
-    os.path.join('obj', 'third_party', 'pdfium', 'fdrm.lib'),
-    os.path.join('obj', 'third_party', 'pdfium', 'formfiller.cc.pdb'),
-    os.path.join('obj', 'third_party', 'pdfium', 'formfiller.lib'),
-    os.path.join('obj', 'third_party', 'pdfium', 'fpdfapi.cc.pdb'),
-    os.path.join('obj', 'third_party', 'pdfium', 'fpdfapi.lib'),
-    os.path.join('obj', 'third_party', 'pdfium', 'fpdfdoc.cc.pdb'),
-    os.path.join('obj', 'third_party', 'pdfium', 'fpdfdoc.lib'),
-    os.path.join('obj', 'third_party', 'pdfium', 'fpdftext.cc.pdb'),
-    os.path.join('obj', 'third_party', 'pdfium', 'fpdftext.lib'),
-    os.path.join('obj', 'third_party', 'pdfium', 'fxcodec.cc.pdb'),
-    os.path.join('obj', 'third_party', 'pdfium', 'fxcodec.lib'),
-    os.path.join('obj', 'third_party', 'pdfium', 'fxcrt.cc.pdb'),
-    os.path.join('obj', 'third_party', 'pdfium', 'fxcrt.lib'),
-    os.path.join('obj', 'third_party', 'pdfium', 'fxedit.cc.pdb'),
-    os.path.join('obj', 'third_party', 'pdfium', 'fxedit.lib'),
-    os.path.join('obj', 'third_party', 'pdfium', 'fxge.cc.pdb'),
-    os.path.join('obj', 'third_party', 'pdfium', 'fxge.lib'),
-    os.path.join('obj', 'third_party', 'pdfium', 'javascript.cc.pdb'),
-    os.path.join('obj', 'third_party', 'pdfium', 'javascript.lib'),
-    os.path.join('obj', 'third_party', 'pdfium', 'pdfwindow.cc.pdb'),
-    os.path.join('obj', 'third_party', 'pdfium', 'pdfwindow.lib'),
-    os.path.join('obj', 'third_party', 'pdfium', 'third_party', 'bigint.cc.pdb'),
-    os.path.join('obj', 'third_party', 'pdfium', 'third_party', 'bigint.lib'),
-    os.path.join('obj', 'third_party', 'pdfium', 'third_party', 'fx_agg.cc.pdb'),
-    os.path.join('obj', 'third_party', 'pdfium', 'third_party', 'fx_agg.lib'),
-    os.path.join('obj', 'third_party', 'pdfium', 'third_party', 'fx_freetype.c.pdb'),
-    os.path.join('obj', 'third_party', 'pdfium', 'third_party', 'fx_freetype.lib'),
-    os.path.join('obj', 'third_party', 'pdfium', 'third_party', 'fx_lcms2.c.pdb'),
-    os.path.join('obj', 'third_party', 'pdfium', 'third_party', 'fx_lcms2.lib'),
-    os.path.join('obj', 'third_party', 'pdfium', 'third_party', 'fx_libopenjpeg.c.pdb'),
-    os.path.join('obj', 'third_party', 'pdfium', 'third_party', 'fx_libopenjpeg.lib'),
-    os.path.join('obj', 'third_party', 'pdfium', 'third_party', 'fx_zlib.c.pdb'),
-    os.path.join('obj', 'third_party', 'pdfium', 'third_party', 'fx_zlib.lib'),
-    os.path.join('obj', 'third_party', 'webrtc', 'base', 'rtc_base.cc.pdb'),
-    os.path.join('obj', 'third_party', 'webrtc', 'base', 'rtc_base.lib'),
-    os.path.join('obj', 'third_party', 'webrtc', 'base', 'rtc_base_approved.cc.pdb'),
-    os.path.join('obj', 'third_party', 'webrtc', 'base', 'rtc_base_approved.lib'),
-    os.path.join('obj', 'third_party', 'webrtc', 'modules', 'desktop_capture.cc.pdb'),
-    os.path.join('obj', 'third_party', 'webrtc', 'modules', 'desktop_capture.lib'),
-    os.path.join('obj', 'third_party', 'webrtc', 'modules', 'desktop_capture_differ_sse2.cc.pdb'),
-    os.path.join('obj', 'third_party', 'webrtc', 'modules', 'desktop_capture_differ_sse2.lib'),
-    os.path.join('obj', 'third_party', 'webrtc', 'system_wrappers', 'system_wrappers.cc.pdb'),
-    os.path.join('obj', 'third_party', 'webrtc', 'system_wrappers', 'system_wrappers.lib'),
-    os.path.join('obj', 'third_party', 'webrtc', 'webrtc_common.cc.pdb'),
-    os.path.join('obj', 'third_party', 'webrtc', 'webrtc_common.lib'),
-    os.path.join('obj', 'ui', 'events', 'dom_keycode_converter.cc.pdb'),
-    os.path.join('obj', 'ui', 'events', 'dom_keycode_converter.lib'),
   ],
 }
 
@@ -355,9 +260,12 @@ def copy_binaries(target_arch, component, output_dir):
     match = '*.{0}'.format(STATIC_LIBRARY_SUFFIX)
 
   if TARGET_PLATFORM == 'darwin':
-    # out/Release/*.{dll,lib}
-    for library in glob.glob(os.path.join(config_dir, match)):
-      copy_with_blacklist(target_arch, library, target_dir)
+    if component == 'shared_library':
+      for library in glob.glob(os.path.join(config_dir, '*.dylib')):
+        copy_with_blacklist(target_arch, library, target_dir)
+    else:
+      for library in glob.glob(os.path.join(config_dir, 'obj', 'chromiumcontent', '*.a')):
+        shutil.copy2(library, target_dir)
 
   if TARGET_PLATFORM == 'win32':
     if component == 'shared_library':
@@ -369,13 +277,9 @@ def copy_binaries(target_arch, component, output_dir):
           copy_with_blacklist(target_arch, lib, target_dir)
     else:
       # On Windows static libraries are placed under subdirs under "obj".
-      for root, _, filenames in os.walk(os.path.join(config_dir, 'obj')):
-        # out/Release/obj/**/*.lib
-        for filename in fnmatch.filter(filenames, '*.lib'):
-          copy_with_blacklist(target_arch, os.path.join(root, filename), target_dir)
-        # out/Release/obj/**/*.pdb
-        for filename in fnmatch.filter(filenames, '*.pdb'):
-          copy_with_blacklist(target_arch, os.path.join(root, filename), target_dir)
+      for library in glob.glob(os.path.join(config_dir, 'obj', 'chromiumcontent', '*.lib')):
+        shutil.copy2(library, target_dir)
+      # TODO: Copy .pdb files
 
   if TARGET_PLATFORM == 'linux':
     if component == 'shared_library':
@@ -405,6 +309,8 @@ def copy_generated_sources(target_arch, component, output_dir):
     copy_headers(include_path,
                  relative_to=os.path.join(output_dir, config, 'gen'),
                  destination=os.path.join(target_dir, 'gen'))
+  shutil.move(os.path.join(target_dir, 'gen', 'content', 'shell', 'grit', 'shell_resources.h'),
+              os.path.join(target_dir, 'gen', 'content', 'grit'))
 
 def copy_locales(target_arch, component, output_dir):
   config = get_configuration(target_arch)

--- a/script/create-dist
+++ b/script/create-dist
@@ -62,26 +62,10 @@ BINARIES = {
     'libffmpeg.dylib',
   ],
   'linux': [
-    'chromedriver',
-    'mksnapshot',
-    'libosmesa.so',
-    'libgtk2ui.a',
-    'libdevtools_discovery.a',
-    'libdevtools_http_handler.a',
-    'libhttp_server.a',
-    'libdesktop_capture.a',
-    'libdesktop_capture_differ_sse2.a',
-    'librtc_base.a',
-    'librtc_base_approved.a',
-    'libwebrtc_common.a',
-    'libyuv.a',
-    'libsystem_wrappers.a',
-    'libcdm_renderer.a',
-    'libsecurity_state.a',
-    'libcookie_config.a',
-    'libos_crypt.a',
-    'libdom_keycode_converter.a',
-    os.path.join('lib', 'libffmpeg.so'),
+# TODO: Take these from the "ffmpeg" output directory
+#    'chromedriver',
+#    'mksnapshot',
+    'libffmpeg.so',
   ],
   'win32': [
 # TODO: Take these from the "ffmpeg" output directory
@@ -98,6 +82,13 @@ BINARIES = {
 
 BINARIES_SHARED_LIBRARY = {
   'darwin': [
+    os.path.join('obj', 'components', 'cdm', 'renderer', 'librenderer.a'),
+    os.path.join('obj', 'net', 'libhttp_server.a'),
+    os.path.join('obj', 'third_party', 'webrtc', 'base', 'librtc_base.a'),
+    os.path.join('obj', 'third_party', 'webrtc', 'base', 'librtc_base_approved.a'),
+    os.path.join('obj', 'ui', 'events', 'libdom_keycode_converter.a'),
+  ],
+  'linux': [
     os.path.join('obj', 'components', 'cdm', 'renderer', 'librenderer.a'),
     os.path.join('obj', 'net', 'libhttp_server.a'),
     os.path.join('obj', 'third_party', 'webrtc', 'base', 'librtc_base.a'),
@@ -342,11 +333,7 @@ def copy_binaries(target_arch, component, output_dir):
   if TARGET_PLATFORM == 'linux':
     if component == 'shared_library':
       # out/Release/lib/*.so
-      for library in glob.glob(os.path.join(config_dir, 'lib', '*.so')):
-        copy_with_blacklist(target_arch, library, target_dir)
-    else:
-      # out/Release/*.a
-      for library in glob.glob(os.path.join(config_dir, '*.a')):
+      for library in glob.glob(os.path.join(config_dir, '*.so')):
         copy_with_blacklist(target_arch, library, target_dir)
 
   if TARGET_PLATFORM in ['linux', 'darwin']:
@@ -399,7 +386,7 @@ def copy_ffmpeg(target_arch):
   if TARGET_PLATFORM == 'darwin':
     binary = 'libffmpeg.dylib'
   elif TARGET_PLATFORM == 'linux':
-    binary = os.path.join('lib', 'libffmpeg.so')
+    binary = 'libffmpeg.so'
   elif TARGET_PLATFORM == 'win32':
     binary = 'ffmpeg.dll'
 

--- a/script/create-dist
+++ b/script/create-dist
@@ -96,6 +96,64 @@ BINARIES = {
   ],
 }
 
+BINARIES_SHARED_LIBRARY = {
+  'darwin': [
+    os.path.join('obj', 'components', 'cdm', 'renderer', 'librenderer.a'),
+    os.path.join('obj', 'net', 'libhttp_server.a'),
+    os.path.join('obj', 'third_party', 'webrtc', 'base', 'librtc_base.a'),
+    os.path.join('obj', 'third_party', 'webrtc', 'base', 'librtc_base_approved.a'),
+    os.path.join('obj', 'ui', 'events', 'libdom_keycode_converter.a'),
+  ],
+  'win32': [
+    os.path.join('obj', 'base', 'base_static_cc.pdb'),
+    os.path.join('obj', 'base', 'base_static.lib'),
+    os.path.join('obj', 'components', 'cdm', 'renderer', 'renderer_cc.pdb'),
+    os.path.join('obj', 'components', 'cdm', 'renderer', 'renderer.lib'),
+    os.path.join('obj', 'net', 'http_server_cc.pdb'),
+    os.path.join('obj', 'net', 'http_server.lib'),
+    os.path.join('obj', 'pdf', 'pdf_cc.pdb'),
+    os.path.join('obj', 'pdf', 'pdf.lib'),
+    os.path.join('obj', 'sandbox', 'win', 'sandbox_cc.pdb'),
+    os.path.join('obj', 'sandbox', 'win', 'sandbox.lib'),
+    os.path.join('obj', 'third_party', 'pdfium', 'pdfium_cc.pdb'),
+    os.path.join('obj', 'third_party', 'pdfium', 'pdfium.lib'),
+    os.path.join('obj', 'third_party', 'pdfium', 'fdrm_cc.pdb'),
+    os.path.join('obj', 'third_party', 'pdfium', 'fdrm.lib'),
+    os.path.join('obj', 'third_party', 'pdfium', 'formfiller_cc.pdb'),
+    os.path.join('obj', 'third_party', 'pdfium', 'formfiller.lib'),
+    os.path.join('obj', 'third_party', 'pdfium', 'fpdfapi_cc.pdb'),
+    os.path.join('obj', 'third_party', 'pdfium', 'fpdfapi.lib'),
+    os.path.join('obj', 'third_party', 'pdfium', 'fpdfdoc_cc.pdb'),
+    os.path.join('obj', 'third_party', 'pdfium', 'fpdfdoc.lib'),
+    os.path.join('obj', 'third_party', 'pdfium', 'fpdftext_cc.pdb'),
+    os.path.join('obj', 'third_party', 'pdfium', 'fpdftext.lib'),
+    os.path.join('obj', 'third_party', 'pdfium', 'fxcodec_cc.pdb'),
+    os.path.join('obj', 'third_party', 'pdfium', 'fxcodec.lib'),
+    os.path.join('obj', 'third_party', 'pdfium', 'fxcrt_cc.pdb'),
+    os.path.join('obj', 'third_party', 'pdfium', 'fxcrt.lib'),
+    os.path.join('obj', 'third_party', 'pdfium', 'fxedit_cc.pdb'),
+    os.path.join('obj', 'third_party', 'pdfium', 'fxedit.lib'),
+    os.path.join('obj', 'third_party', 'pdfium', 'fxge_cc.pdb'),
+    os.path.join('obj', 'third_party', 'pdfium', 'fxge.lib'),
+    os.path.join('obj', 'third_party', 'pdfium', 'javascript_cc.pdb'),
+    os.path.join('obj', 'third_party', 'pdfium', 'javascript.lib'),
+    os.path.join('obj', 'third_party', 'pdfium', 'pdfwindow_cc.pdb'),
+    os.path.join('obj', 'third_party', 'pdfium', 'pdfwindow.lib'),
+    os.path.join('obj', 'third_party', 'pdfium', 'third_party', 'bigint_cc.pdb'),
+    os.path.join('obj', 'third_party', 'pdfium', 'third_party', 'fx_agg_cc.pdb'),
+    os.path.join('obj', 'third_party', 'pdfium', 'third_party', 'fx_freetype_c.pdb'),
+    os.path.join('obj', 'third_party', 'pdfium', 'third_party', 'fx_freetype.lib'),
+    os.path.join('obj', 'third_party', 'pdfium', 'third_party', 'fx_lcms2_c.pdb'),
+    os.path.join('obj', 'third_party', 'pdfium', 'third_party', 'fx_libopenjpeg_c.pdb'),
+    os.path.join('obj', 'third_party', 'pdfium', 'third_party', 'fx_zlib_c.pdb'),
+    os.path.join('obj', 'third_party', 'webrtc', 'base', 'rtc_base_cc.pdb'),
+    os.path.join('obj', 'third_party', 'webrtc', 'base', 'rtc_base.lib'),
+    os.path.join('obj', 'third_party', 'webrtc', 'base', 'rtc_base_approved_cc.pdb'),
+    os.path.join('obj', 'third_party', 'webrtc', 'base', 'rtc_base_approved.lib'),
+    os.path.join('obj', 'ui', 'events', 'dom_keycode_converter.lib'),
+  ],
+}
+
 ARCH_BLACKLIST = {
   'arm': [
     'libdesktop_capture_differ_sse2.a',
@@ -251,8 +309,16 @@ def copy_binaries(target_arch, component, output_dir):
   target_dir = os.path.join(MAIN_DIR, component)
   mkdir_p(target_dir)
 
-  for binary in BINARIES['all'] + BINARIES[TARGET_PLATFORM]:
+  binaries = BINARIES['all'] + BINARIES[TARGET_PLATFORM]
+  if component == 'shared_library':
+    binaries += BINARIES_SHARED_LIBRARY[TARGET_PLATFORM]
+  for binary in binaries:
     copy_with_blacklist(target_arch, os.path.join(config_dir, binary), target_dir)
+
+  # Copy all static libraries from chromiumcontent
+  for library in glob.glob(os.path.join(config_dir, 'obj', 'chromiumcontent', '*.' + STATIC_LIBRARY_SUFFIX)):
+    shutil.copy2(library, target_dir)
+  # TODO: Copy .pdb files
 
   if component == 'shared_library':
     match = '*.{0}'.format(SHARED_LIBRARY_SUFFIX)
@@ -263,9 +329,6 @@ def copy_binaries(target_arch, component, output_dir):
     if component == 'shared_library':
       for library in glob.glob(os.path.join(config_dir, '*.dylib')):
         copy_with_blacklist(target_arch, library, target_dir)
-    else:
-      for library in glob.glob(os.path.join(config_dir, 'obj', 'chromiumcontent', '*.a')):
-        shutil.copy2(library, target_dir)
 
   if TARGET_PLATFORM == 'win32':
     if component == 'shared_library':
@@ -275,11 +338,6 @@ def copy_binaries(target_arch, component, output_dir):
         if os.path.exists(lib):
           copy_with_blacklist(target_arch, dll, target_dir)
           copy_with_blacklist(target_arch, lib, target_dir)
-    else:
-      # On Windows static libraries are placed under subdirs under "obj".
-      for library in glob.glob(os.path.join(config_dir, 'obj', 'chromiumcontent', '*.lib')):
-        shutil.copy2(library, target_dir)
-      # TODO: Copy .pdb files
 
   if TARGET_PLATFORM == 'linux':
     if component == 'shared_library':

--- a/script/update
+++ b/script/update
@@ -20,16 +20,12 @@ CHROMIUMCONTENT_SOURCE_DIR = os.path.join(SOURCE_ROOT, 'chromiumcontent')
 CHROMIUMCONTENT_DESTINATION_DIR = os.path.join(SRC_DIR, 'chromiumcontent')
 COMPONENTS = ['static_library', 'shared_library', 'ffmpeg']
 
-TARBALL_REPO = 'zcbenz/chromium-source-tarball'
-TARBALL_URL = 'https://github.com/{0}/releases/download/{1}/chromium-{1}.tar.xz'
-
-
 def main():
   args = parse_args()
 
-#  version = chromium_version()
-#  if not is_source_tarball_updated(version):
-#    download_source_tarball(version)
+  version = chromium_version()
+  if not is_source_up_to_date(version):
+    download_source(version)
 
   if sys.platform == 'linux2':
     install_sysroot()
@@ -55,7 +51,7 @@ def chromium_version():
     return f.readline().strip()
 
 
-def is_source_tarball_updated(version):
+def is_source_up_to_date(version):
   version_file = os.path.join(SRC_DIR, '.version')
   existing_version = ''
   try:
@@ -68,35 +64,22 @@ def is_source_tarball_updated(version):
   return existing_version == version
 
 
-def download_source_tarball(version):
-  rm_rf(SRC_DIR)
+def download_source(version):
+  # Put vendor/depot_tools on the PATH
+  depot_tools = os.path.join(VENDOR_DIR, 'depot_tools')
+  env = os.environ.copy()
+  env['PATH'] = depot_tools + os.pathsep + env['PATH']
 
-  dir_name = 'chromium-{0}'.format(version)
-  tar_name = dir_name + '.tar'
-  xz_name = tar_name + '.xz'
-  url = TARBALL_URL.format(TARBALL_REPO, version)
-  with open(xz_name, 'wb+') as t:
-    with contextlib.closing(urllib2.urlopen(url)) as u:
-      while True:
-        chunk = u.read(1024*1024)
-        if not len(chunk):
-            break
-        sys.stderr.write('.')
-        sys.stderr.flush()
-        t.write(chunk)
+  gclient_file = os.path.join(SOURCE_ROOT, '.gclient')
+  if not os.path.exists(gclient_file) or not os.path.exists(SRC_DIR):
+    rm_rf(SRC_DIR)
+    fetch = os.path.join(depot_tools, 'fetch.py')
+    subprocess.check_call([sys.executable, fetch, 'chromium'], env=env)
 
-  sys.stderr.write('\nExtracting...\n')
-  sys.stderr.flush()
-
-  rm_f(tar_name)
-  tar_xf(xz_name)
-  os.rename(dir_name, SRC_DIR)
-  os.remove(xz_name)
-
-  version_file = os.path.join(SRC_DIR, '.version')
-  with open(version_file, 'w+') as f:
-    f.write(version)
-
+  gclient = os.path.join(depot_tools, 'gclient.py')
+  subprocess.check_call([sys.executable, gclient, 'sync', '--revision',
+                         'src@' + version, '--with_branch_heads', '--reset'],
+                        env=env)
 
 def install_sysroot():
   for arch in ('arm', 'amd64', 'i386'):

--- a/script/update
+++ b/script/update
@@ -10,7 +10,7 @@ import tarfile
 import tempfile
 import urllib2
 
-from lib.config import get_output_dir
+from lib.config import get_configuration, get_output_dir
 
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
@@ -27,9 +27,9 @@ TARBALL_URL = 'https://github.com/{0}/releases/download/{1}/chromium-{1}.tar.xz'
 def main():
   args = parse_args()
 
-  version = chromium_version()
-  if not is_source_tarball_updated(version):
-    download_source_tarball(version)
+#  version = chromium_version()
+#  if not is_source_tarball_updated(version):
+#    download_source_tarball(version)
 
   if sys.platform == 'linux2':
     install_sysroot()
@@ -38,7 +38,8 @@ def main():
   return (apply_patches() or
           copy_chromiumcontent_files() or
           update_clang() or
-          run_gyp(target_arch, args.defines))
+          update_gn() or
+          run_gn(target_arch, args.defines))
 
 
 def parse_args():
@@ -162,7 +163,9 @@ def copy_chromiumcontent_files():
       raise
   for dirpath, dirnames, filenames in os.walk(CHROMIUMCONTENT_SOURCE_DIR):
     for dirname in dirnames:
-      mkdir_p(os.path.join(dirpath, dirname))
+      source = os.path.join(dirpath, dirname)
+      relative = os.path.relpath(source, start=CHROMIUMCONTENT_SOURCE_DIR)
+      mkdir_p(os.path.join(CHROMIUMCONTENT_DESTINATION_DIR, relative))
     for filename in filenames:
       source = os.path.join(dirpath, filename)
       relative = os.path.relpath(source, start=CHROMIUMCONTENT_SOURCE_DIR)
@@ -192,6 +195,43 @@ def run_gyp(target_arch, defines):
           os.path.join(relative_dir, 'chromiumcontent.gyp')]
   for component in COMPONENTS:
     subprocess.call(args, env=gyp_env(target_arch, component, defines))
+
+
+def update_gn():
+  download = os.path.join(VENDOR_DIR, 'depot_tools', 'download_from_google_storage.py')
+  if sys.platform in ['win32', 'cygwin']:
+    platform = 'win32'
+    key = 'win/gn.exe.sha1'
+  elif sys.platform == 'darwin':
+    platform = 'darwin'
+    key = 'mac/gn.sha1'
+  else:
+    platform = 'linux*'
+    key = 'linux64/gn.sha1'
+  subprocess.call([sys.executable, download, '--no_resume',
+                   '--platform={0}'.format(platform), '--no_auth', '--bucket',
+                   'chromium-gn', '-s', 'buildtools/{0}'.format(key)],
+                  cwd=SRC_DIR)
+
+
+def run_gn(target_arch, defines):
+  gn = os.path.join(VENDOR_DIR, 'depot_tools', 'gn.py')
+
+  env = os.environ.copy()
+  if sys.platform in ['win32', 'cygwin']:
+    env['DEPOT_TOOLS_WIN_TOOLCHAIN'] = '0'
+
+  if target_arch == 'ia32':
+    target_cpu = 'x86'
+  else:
+    target_cpu = target_arch
+
+  for component in COMPONENTS:
+    args = 'import("//chromiumcontent/args/{0}.gn") target_cpu="{1}"'.format(component, target_cpu)
+    output_dir = os.path.join(get_output_dir(target_arch, component),
+                              get_configuration(target_arch))
+    subprocess.call([sys.executable, gn, 'gen', output_dir, '--args=' + args],
+                    cwd=SRC_DIR, env=env)
 
 
 def xz():

--- a/script/update
+++ b/script/update
@@ -208,10 +208,10 @@ def update_gn():
   else:
     platform = 'linux*'
     key = 'linux64/gn.sha1'
-  subprocess.call([sys.executable, download, '--no_resume',
-                   '--platform={0}'.format(platform), '--no_auth', '--bucket',
-                   'chromium-gn', '-s', 'buildtools/{0}'.format(key)],
-                  cwd=SRC_DIR)
+  return subprocess.call([sys.executable, download, '--no_resume',
+                          '--platform={0}'.format(platform), '--no_auth', '--bucket',
+                          'chromium-gn', '-s', 'buildtools/{0}'.format(key)],
+                         cwd=SRC_DIR)
 
 
 def run_gn(target_arch, defines):


### PR DESCRIPTION
This is not yet a full migration to GN. It still doesn't cover all platforms and configurations. More changes need to be done to make it a full replacement of the old GYP based build, but I want to let others to have a look so that we can have a discussion about the approach.

**A few notes about this approach** (and how it differs from what #239 does):

- Main point: no changes to the GN tool

- It's limited to the libchromiumcontent repo, no changes needed in other repos.
  > Note: Electron needs a few small changes that I consider bug fixes. More on that below.

- It's backwards compatible with the current pipeline: build libcc -> create-dist -> run `generate_filenames_gypi` -> build Electron

- I wanted to keep Chromium's GN build files work the same when not configuring for Electron build. It should remain possible to build Chromium normally even with our patches applied.

- I made use of the possibility to specify build arguments in static .gn files (in the `chromiumcontent/args` subdirectory) and import them when running `gn gen`. This allows easier custom configurations (e.g. various Chromium features enabled/disabled, like webrtc or others)

- I used a trick to build static libraries out of the .obj files produced by the `source_set` targets. I let the build run, then re-run it to build the libs (more info in `chromiumcontent/BUILD.gn`). This is handy to keep compatibility with the existing pipeline, but it's not necessary. We could just distribute the .obj files and link them to Electron (tried it and works). That would require a small change to Electron's GYP files, but the end result would be the same.

- The statically linked executables `mksnapshot` and `chromedriver` need to be built in a configuration which doesn't tweak ICU and V8 to make them exportable from `node.dll`. That config can be the "FFMPEG" one and I mention that plan in TODO comments.

**Changes to the Electron repo**

- With this change, [this workaround](https://github.com/electron/electron/blob/master/atom/common/node_bindings.cc#L66-L72) can be removed

- I wanted to make sure that every source file is built with the right set of defines which don't conflict with one another. So in case of V8, it's built with `BUILDING_V8_SHARED` and consumed with `USING_V8_SHARED`. Therefore the latter needs to be added to Electron's GYP file. 

**Stuff that needs to be done still**

- This now works on Windows and Mac with the `static_library` build. There are some Mac linker questions I need help with.
- Linux `static_library` and `shared_library` are not done yet.
- I need to understand the purpose of the `ffmpeg` config.

I fully acknowledge that something about these changes may not work in some important scenario that I am not aware of. Please let me know if that is the case.
