### PR TITLE
Add VSTS build for Mac CI

### DIFF
--- a/script/reportbuild/.gitignore
+++ b/script/reportbuild/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/script/reportbuild/package-lock.json
+++ b/script/reportbuild/package-lock.json
@@ -1,0 +1,103 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@octokit/rest": {
+      "version": "15.2.6",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.2.6.tgz",
+      "integrity": "sha512-KcqG0zjnjzUqn7wczz/fKiueNpTLiAI7erhUG6bXWAsYKJJlqnwYonFSXrMW/nmes5y+qOk4uSyHBh1mdRXdVQ==",
+      "requires": {
+        "before-after-hook": "1.1.0",
+        "btoa-lite": "1.0.0",
+        "debug": "3.1.0",
+        "http-proxy-agent": "2.1.0",
+        "https-proxy-agent": "2.2.1",
+        "lodash": "4.17.5",
+        "node-fetch": "2.1.2",
+        "url-template": "2.0.8"
+      }
+    },
+    "agent-base": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+      "requires": {
+        "es6-promisify": "5.0.0"
+      }
+    },
+    "before-after-hook": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
+      "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA=="
+    },
+    "btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "4.2.4"
+      }
+    },
+    "http-proxy-agent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "requires": {
+        "agent-base": "4.2.0",
+        "debug": "3.1.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "4.2.0",
+        "debug": "3.1.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node-fetch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
+    }
+  }
+}

--- a/script/reportbuild/package.json
+++ b/script/reportbuild/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "@octokit/rest": "^15.2.6",
+    "minimist": "^1.2.0"
+  }
+}

--- a/script/reportbuild/upload-build-results.js
+++ b/script/reportbuild/upload-build-results.js
@@ -1,0 +1,39 @@
+const args = require('minimist')(process.argv.slice(2))
+const assert = require('assert')
+const octokit = require('@octokit/rest')()
+const s3Url = 'https://s3.amazonaws.com/github-janky-artifacts/libchromiumcontent'
+
+assert(process.env.LIBCHROMIUMCONTENT_GITHUB_TOKEN, 'LIBCHROMIUMCONTENT_GITHUB_TOKEN not found in environment')
+
+async function postBuildResults () {
+  octokit.authenticate({
+    type: 'oauth',
+    token: process.env.LIBCHROMIUMCONTENT_GITHUB_TOKEN
+  })
+
+  try {
+    let buildSummary
+    if (args.failed) {
+      buildSummary = `:x: ${args.buildName} failed for ${args.commitId}.`
+    } else {
+      buildSummary = `:white_check_mark: ${args.buildName} succeeded for ${args.commitId}.`
+    }
+    let body = `${buildSummary}  [Details](${s3Url}/${args.logFile})`
+    const githubOpts = {
+      owner: 'electron',
+      repo: 'libchromiumcontent',
+      number: args.prNumber,
+      body
+    }
+    await octokit.issues.createComment(githubOpts)
+  } catch (ex) {
+    console.log(`Error uploading build results`, ex)
+  }
+}
+
+if (!args.buildName || !args.logFile || !args.prNumber || !args.commitId) {
+  console.log(`Usage: upload-build-results --buildname=BUILD_NAME ` +
+    `--logFile=LOG_FILE --prNumber=PR_NUMBER, --commitId=COMMIT_ID`)
+  process.exit(1)
+}
+postBuildResults()

--- a/vsts.yml
+++ b/vsts.yml
@@ -1,0 +1,104 @@
+resources:
+- repo: self
+phases:
+- phase: Build_libchromiumcontent
+  condition: or(eq(variables['System.PullRequest.IsFork'], 'True'), ne(variables['Build.Reason'], 'PullRequest'))
+  queue:
+    parallel: 4
+    timeoutInMinutes: 180
+    matrix:
+      libchromiumcontent-mas-shared:
+        COMPONENT: shared_library
+        MAS_BUILD: 1
+        TARGET_ARCH: x64
+        TARGET_TYPE: mas
+      libchromiumcontent-mas-static:
+        COMPONENT: static_library
+        MAS_BUILD: 1
+        TARGET_ARCH: x64
+        TARGET_TYPE: mas
+      libchromiumcontent-osx-shared:
+        COMPONENT: shared_library
+        TARGET_ARCH: x64
+        TARGET_TYPE: osx
+      libchromiumcontent-osx-static:
+        COMPONENT: static_library
+        TARGET_ARCH: x64
+        TARGET_TYPE: osx
+
+  steps:
+  - bash: |
+     set -e
+     if [[ -z "${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER}" ]] || "${SYSTEM_PULLREQUEST_ISFORK}" == "True"; then
+       echo "##vso[task.setvariable variable=gitcommit]$BUILD_SOURCEVERSION"
+     else
+       tmp="${BUILD_SOURCEVERSIONMESSAGE/#Merge /}"
+       PR_COMMIT_ID="${tmp%% into*}"
+       echo "PR is for repo branch, using original commit $PR_COMMIT_ID"
+       echo "##vso[task.setvariable variable=gitcommit]$PR_COMMIT_ID"
+       echo "Checking out $PR_COMMIT_ID"
+       git checkout $PR_COMMIT_ID
+       echo "Now switched to `git rev-parse HEAD`"
+     fi
+    name: Get_commit
+
+  - bash: |
+     set -e
+     echo "===Bootstrapping===" > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
+     script/bootstrap > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
+    name: Bootstrap
+
+  - bash: |
+     echo "===Updating for $TARGET_ARCH===" > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
+     script/update --clean -t $TARGET_ARCH > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
+    name: Update
+
+  - bash: |
+     echo "===Building $COMPONENT for $TARGET_ARCH===" > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
+     script/build -t $TARGET_ARCH -c $COMPONENT > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
+    name: Build_library
+
+  - bash: |
+     echo "===Building ffmpeg for $TARGET_ARCH===" > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
+     script/build -t $TARGET_ARCH -c ffmpeg > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
+    name: Build_ffmpeg
+
+  - bash: |
+     echo "===Create $COMPONENT distribution for $TARGET_ARCH===" > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
+     script/create-dist -t $TARGET_ARCH -c $COMPONENT > >(tee -a buildlog.txt) 2> >(tee -a buildlog.txt >&2)
+     mkdir s3files
+     mv libchromiumcontent* s3files
+     mv buildlog.txt s3files
+    name: Create_distribution
+
+  - task: AmazonWebServices.aws-vsts-tools.S3Upload.S3Upload@1
+    inputs:
+      awsCredentials: 'Libchromium Content S3'
+      regionName: 'us-east-1'
+      bucketName: 'github-janky-artifacts'
+      sourceFolder: s3files
+      globExpressions: '*'
+      targetFolder: 'libchromiumcontent/$(TARGET_TYPE)/$(TARGET_ARCH)/$(gitcommit)'
+      filesAcl: 'public-read'
+      logRequest: true
+      logResponse: true
+
+  - bash: |
+     if [[ -z "${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER}" ]]; then
+       echo "Skipping build results upload because there is not a PR number"
+     else
+       npm install --prefix ./script/reportbuild
+       LIBCHROMIUMCONTENT_GITHUB_TOKEN=$(LIBCHROMIUMCONTENT_GITHUB_TOKEN) node script/reportbuild/upload-build-results.js --buildName="$AGENT_JOBNAME" --logFile="$(TARGET_TYPE)/$(TARGET_ARCH)/$(gitcommit)/buildlog.txt" --prNumber="$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER" --commitId="$BUILD_SOURCEVERSION" --failed
+      fi
+    condition: failed()
+
+  - bash: |
+     if [[ -z "${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER}" ]]; then
+       echo "Skipping build results upload because there is not a PR number"
+     else
+       npm install --prefix ./script/reportbuild
+       LIBCHROMIUMCONTENT_GITHUB_TOKEN=$(LIBCHROMIUMCONTENT_GITHUB_TOKEN) node script/reportbuild/upload-build-results.js --buildName="$AGENT_JOBNAME" --logFile="$(TARGET_TYPE)/$(TARGET_ARCH)/$(gitcommit)/buildlog.txt" --prNumber="$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER" --commitId="$BUILD_SOURCEVERSION"
+      fi
+
+  - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
+    condition: always()


### PR DESCRIPTION
This adds Mac CI builds back for 1-8-x.  The latest electron-1-8-x commit does not have mac builds because we switch Mac CI and never updated 1-8-x to the new provider (VSTS)