### PR TITLE
fix: expose libgtkui::GetBgColor (backport: 3-0-x)

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -398,3 +398,8 @@ patches:
     This is part of the fixes for https://github.com/electron/electron/issues/14211.
     We should revisit this bug after upgrading to newer versions of Chrome,
     this patch was introduced in Chrome 66.
+-
+  author: Shelley Vohr <shelley.vohr@gmail.com>
+  file: libgtkui_export.patch
+  description: |
+    Export libgtkui symbols for the GN component build.

--- a/patches/common/chromium/libgtkui_export.patch
+++ b/patches/common/chromium/libgtkui_export.patch
@@ -1,0 +1,21 @@
+diff --git a/chrome/browser/ui/libgtkui/gtk_util.h b/chrome/browser/ui/libgtkui/gtk_util.h
+index 665ec57..4ccb088 100644
+--- a/chrome/browser/ui/libgtkui/gtk_util.h
++++ b/chrome/browser/ui/libgtkui/gtk_util.h
+@@ -11,6 +11,7 @@
+ #include "ui/base/glib/scoped_gobject.h"
+ #include "ui/native_theme/native_theme.h"
+ #include "ui/views/window/frame_buttons.h"
++#include "chrome/browser/ui/libgtkui/libgtkui_export.h"
+ 
+ namespace aura {
+ class Window;
+@@ -190,7 +190,7 @@ void RenderBackground(const gfx::Size& size,
+ // Renders a background from the style context created by
+ // GetStyleContextFromCss(|css_selector|) into a 24x24 bitmap and
+ // returns the average color.
+-SkColor GetBgColor(const std::string& css_selector);
++LIBGTKUI_EXPORT SkColor GetBgColor(const std::string& css_selector);
+ 
+ // Renders the border from the style context created by
+ // GetStyleContextFromCss(|css_selector|) into a 24x24 bitmap and


### PR DESCRIPTION
##### Description of Change

Backport libcc portion of https://github.com/electron/electron/pull/14785 to `3-0-x`.

/cc @alexeykuzmin 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] Patch information is added to appropriate `.patches.yaml`
- [ ] `script/update` runs without error
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)