### PR TITLE
fix: add a node_integration field to WebPreferences

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -403,3 +403,12 @@ patches:
   file: libgtkui_export.patch
   description: |
     Export libgtkui symbols for the GN component build.
+-
+  author: zcbenz <zcbenz@gmail.com>
+  file: web_preferences.patch
+  description: |
+    Add a node_integration field to WebPreferences so we can determine whether
+    a frame has node integration in renderer process.
+
+    This is required by the nativeWindowOpen option, which put multiple main
+    frames in one renderer process.

--- a/patches/common/chromium/web_preferences.patch
+++ b/patches/common/chromium/web_preferences.patch
@@ -1,0 +1,26 @@
+diff --git a/content/public/common/common_param_traits_macros.h b/content/public/common/common_param_traits_macros.h
+index 6b1fa1c..474eaa0 100644
+--- a/content/public/common/common_param_traits_macros.h
++++ b/content/public/common/common_param_traits_macros.h
+@@ -191,6 +191,7 @@ IPC_STRUCT_TRAITS_BEGIN(content::WebPreferences)
+   IPC_STRUCT_TRAITS_MEMBER(animation_policy)
+   IPC_STRUCT_TRAITS_MEMBER(user_gesture_required_for_presentation)
+   IPC_STRUCT_TRAITS_MEMBER(text_track_margin_percentage)
++  IPC_STRUCT_TRAITS_MEMBER(node_integration)
+   IPC_STRUCT_TRAITS_MEMBER(save_previous_document_resources)
+ #if defined(OS_ANDROID)
+   IPC_STRUCT_TRAITS_MEMBER(text_autosizing_enabled)
+diff --git a/content/public/common/web_preferences.h b/content/public/common/web_preferences.h
+index 43606a7..d20b433 100644
+--- a/content/public/common/web_preferences.h
++++ b/content/public/common/web_preferences.h
+@@ -210,6 +210,9 @@ struct CONTENT_EXPORT WebPreferences {
+   // Cues will not be placed in this margin area.
+   float text_track_margin_percentage;
+ 
++  // Electron: Whether the frame has node integration.
++  bool node_integration = false;
++
+   bool immersive_mode_enabled;
+ 
+ #if defined(OS_ANDROID)


### PR DESCRIPTION
Backport libcc patch of https://github.com/electron/electron/pull/15076 to `electron-3-0-x`.

Notes: Partially fix a memory leak when opening child windows with nativeWindowOpen.