### PR TITLE
fix: proxy resolution from pac file for ws requests on windows and macOS (3-0-x)

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -412,3 +412,10 @@ patches:
 
     This is required by the nativeWindowOpen option, which put multiple main
     frames in one renderer process.
+-
+  author: deepak1556 <hop2deep@gmail.com>
+  file: proxy_resolution_win_http.patch
+  description: |
+    Backport https://chromium-review.googlesource.com/c/chromium/src/+/1143093
+    Fixes proxy resolution from pac file with ws(s) requests when using platform
+    proxy resolvers on windows and macOS.

--- a/patches/common/chromium/proxy_resolution_win_http.patch
+++ b/patches/common/chromium/proxy_resolution_win_http.patch
@@ -1,0 +1,75 @@
+diff --git a/net/proxy_resolution/proxy_resolver_mac.cc b/net/proxy_resolution/proxy_resolver_mac.cc
+index 6d13cbd72af9..4c50e7b6eca9 100644
+--- a/net/proxy_resolution/proxy_resolver_mac.cc
++++ b/net/proxy_resolution/proxy_resolver_mac.cc
+@@ -18,6 +18,7 @@
+ #include "net/base/proxy_server.h"
+ #include "net/proxy_resolution/proxy_info.h"
+ #include "net/proxy_resolution/proxy_resolver.h"
++#include "url/gurl.h"
+ 
+ #if defined(OS_IOS)
+ #include <CFNetwork/CFProxySupport.h>
+@@ -212,8 +213,17 @@ int ProxyResolverMac::GetProxyForURL(const GURL& query_url,
+                                      const CompletionCallback& /*callback*/,
+                                      std::unique_ptr<Request>* /*request*/,
+                                      const NetLogWithSource& net_log) {
++  // OS X's system resolver does not support WebSocket URLs in proxy.pac, as of
++  // version 10.13.5. See https://crbug.com/862121.
++  GURL mutable_query_url = query_url;
++  if (query_url.SchemeIsWSOrWSS()) {
++    GURL::Replacements replacements;
++    replacements.SetSchemeStr(query_url.SchemeIsCryptographic() ? "https"
++                                                                : "http");
++    mutable_query_url = query_url.ReplaceComponents(replacements);
++  }
+   base::ScopedCFTypeRef<CFStringRef> query_ref(
+-      base::SysUTF8ToCFStringRef(query_url.spec()));
++      base::SysUTF8ToCFStringRef(mutable_query_url.spec()));
+   base::ScopedCFTypeRef<CFURLRef> query_url_ref(
+       CFURLCreateWithString(kCFAllocatorDefault, query_ref.get(), NULL));
+   if (!query_url_ref.get())
+diff --git a/net/proxy_resolution/proxy_resolver_winhttp.cc b/net/proxy_resolution/proxy_resolver_winhttp.cc
+index ebe5fb8dca26..dba7dcce6abd 100644
+--- a/net/proxy_resolution/proxy_resolver_winhttp.cc
++++ b/net/proxy_resolution/proxy_resolver_winhttp.cc
+@@ -96,6 +96,20 @@ int ProxyResolverWinHttp::GetProxyForURL(const GURL& query_url,
+   if (!session_handle_ && !OpenWinHttpSession())
+     return ERR_FAILED;
+ 
++  // Windows' system resolver does not support WebSocket URLs in proxy.pac. This
++  // was tested in version 10.0.16299, and is also implied by the description of
++  // the ERROR_WINHTTP_UNRECOGNIZED_SCHEME error code in the Microsoft
++  // documentation at
++  // https://docs.microsoft.com/en-us/windows/desktop/api/winhttp/nf-winhttp-winhttpgetproxyforurl.
++  // See https://crbug.com/862121.
++  GURL mutable_query_url = query_url;
++  if (query_url.SchemeIsWSOrWSS()) {
++    GURL::Replacements replacements;
++    replacements.SetSchemeStr(query_url.SchemeIsCryptographic() ? "https"
++                                                                : "http");
++    mutable_query_url = query_url.ReplaceComponents(replacements);
++  }
++
+   // If we have been given an empty PAC url, then use auto-detection.
+   //
+   // NOTE: We just use DNS-based auto-detection here like Firefox.  We do this
+@@ -116,14 +130,14 @@ int ProxyResolverWinHttp::GetProxyForURL(const GURL& query_url,
+   // Otherwise, we fail over to trying it with a value of true.  This way we
+   // get good performance in the case where WinHTTP uses an out-of-process
+   // resolver.  This is important for Vista and Win2k3.
+-  BOOL ok = WinHttpGetProxyForUrl(session_handle_,
+-                                  base::ASCIIToUTF16(query_url.spec()).c_str(),
+-                                  &options, &info);
++  BOOL ok = WinHttpGetProxyForUrl(
++      session_handle_, base::ASCIIToUTF16(mutable_query_url.spec()).c_str(),
++      &options, &info);
+   if (!ok) {
+     if (ERROR_WINHTTP_LOGIN_FAILURE == GetLastError()) {
+       options.fAutoLogonIfChallenged = TRUE;
+       ok = WinHttpGetProxyForUrl(
+-          session_handle_, base::ASCIIToUTF16(query_url.spec()).c_str(),
++          session_handle_, base::ASCIIToUTF16(mutable_query_url.spec()).c_str(),
+           &options, &info);
+     }
+     if (!ok) {


### PR DESCRIPTION
##### Description of Change

Backports https://chromium-review.googlesource.com/c/chromium/src/+/1143093
Fixes https://github.com/electron/electron/issues/15344

This is not required for versions greater than 3.x because we changed to use chromium proxy resolver implementation with https://github.com/electron/electron/pull/14656

And also it is not required for versions less than 3.x as the switch to platform proxy resolver was made temporarily only for ch 66 upgrade due to lack of support for mojo network context apis.

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] Patch information is added to appropriate `.patches.yaml`
- [x] `script/update` runs without error
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)