### PR TITLE
fix: don't append Shift modifier text twice to accelerators

### DIFF
--- a/patches/common/chromium/accelerator.patch
+++ b/patches/common/chromium/accelerator.patch
@@ -1,5 +1,5 @@
 diff --git a/ui/base/accelerators/accelerator.cc b/ui/base/accelerators/accelerator.cc
-index 0694f7433df5..7df31b1919e6 100644
+index 0694f7433df5..a22ef96a7307 100644
 --- a/ui/base/accelerators/accelerator.cc
 +++ b/ui/base/accelerators/accelerator.cc
 @@ -9,6 +9,7 @@
@@ -13,16 +13,16 @@ index 0694f7433df5..7df31b1919e6 100644
 @@ -19,9 +20,7 @@
  #include <windows.h>
  #endif
- 
+
 -#if !defined(OS_WIN) && (defined(USE_AURA) || defined(OS_MACOSX))
  #include "ui/events/keycodes/keyboard_code_conversion.h"
 -#endif
- 
+
  namespace ui {
- 
+
 @@ -210,7 +209,14 @@ base::string16 Accelerator::GetShortcutText() const {
    }
- 
+
    base::string16 shortcut;
 +  unsigned int flags = 0;
    if (!string_id) {
@@ -35,7 +35,7 @@ index 0694f7433df5..7df31b1919e6 100644
  #if defined(OS_WIN)
      // Our fallback is to try translate the key code to a regular character
      // unless it is one of digits (VK_0 to VK_9). Some keyboard
-@@ -219,20 +225,18 @@ base::string16 Accelerator::GetShortcutText() const {
+@@ -219,18 +225,14 @@ base::string16 Accelerator::GetShortcutText() const {
      // accent' for '0'). For display in the menu (e.g. Ctrl-0 for the
      // default zoom level), we leave VK_[0-9] alone without translation.
      wchar_t key;
@@ -59,12 +59,8 @@ index 0694f7433df5..7df31b1919e6 100644
 +          base::StringPrintf("F%d", key_code_ - VKEY_F1 + 1));
    } else {
      shortcut = l10n_util::GetStringUTF16(string_id);
-+    if (IsShiftDown())
-+      shortcut = l10n_util::GetStringFUTF16(IDS_APP_SHIFT_MODIFIER, shortcut);
    }
- 
-   // Checking whether the character used for the accelerator is alphanumeric.
-@@ -255,7 +259,8 @@ base::string16 Accelerator::GetShortcutText() const {
+@@ -255,7 +257,8 @@ base::string16 Accelerator::GetShortcutText() const {
    // more information.
    if (IsCtrlDown())
      shortcut = l10n_util::GetStringFUTF16(IDS_APP_CONTROL_MODIFIER, shortcut);
@@ -72,5 +68,5 @@ index 0694f7433df5..7df31b1919e6 100644
 +
 +  if (IsAltDown())
      shortcut = l10n_util::GetStringFUTF16(IDS_APP_ALT_MODIFIER, shortcut);
- 
+
    if (IsCmdDown()) {

--- a/patches/common/chromium/accelerator.patch
+++ b/patches/common/chromium/accelerator.patch
@@ -13,16 +13,16 @@ index 0694f7433df5..a22ef96a7307 100644
 @@ -19,9 +20,7 @@
  #include <windows.h>
  #endif
-
+ 
 -#if !defined(OS_WIN) && (defined(USE_AURA) || defined(OS_MACOSX))
  #include "ui/events/keycodes/keyboard_code_conversion.h"
 -#endif
-
+ 
  namespace ui {
-
+ 
 @@ -210,7 +209,14 @@ base::string16 Accelerator::GetShortcutText() const {
    }
-
+ 
    base::string16 shortcut;
 +  unsigned int flags = 0;
    if (!string_id) {
@@ -68,5 +68,5 @@ index 0694f7433df5..a22ef96a7307 100644
 +
 +  if (IsAltDown())
      shortcut = l10n_util::GetStringFUTF16(IDS_APP_ALT_MODIFIER, shortcut);
-
+ 
    if (IsCmdDown()) {


### PR DESCRIPTION
Backport of electron/electron#15400 to `3-0-x`