### PR TITLE
fix: backport: SQLitePersistentCookieStore: recover from uniqueness violat…

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -419,3 +419,9 @@ patches:
     Backport https://chromium-review.googlesource.com/c/chromium/src/+/1143093
     Fixes proxy resolution from pac file with ws(s) requests when using platform
     proxy resolvers on windows and macOS.
+-
+  owners: alexeykuzmin
+  file: backport_6c41b439b.patch
+  description: |
+    Backports http://crrev.com/6c41b439b9e299354f86b91426ff0f7196c13f90
+    SQLitePersistentCookieStore: recover from uniqueness violation on V9->V10 migration

--- a/patches/common/chromium/backport_6c41b439b.patch
+++ b/patches/common/chromium/backport_6c41b439b.patch
@@ -1,0 +1,37 @@
+6c41b439b9e299354f86b91426ff0f7196c13f90
+diff --git a/net/extras/sqlite/sqlite_persistent_cookie_store.cc b/net/extras/sqlite/sqlite_persistent_cookie_store.cc
+index 7313ddfac9da..1fb9bec2ea75 100644
+--- a/net/extras/sqlite/sqlite_persistent_cookie_store.cc
++++ b/net/extras/sqlite/sqlite_persistent_cookie_store.cc
+@@ -1178,26 +1178,18 @@ bool SQLitePersistentCookieStore::Backend::EnsureDatabaseVersion() {
+       return false;
+     }
+     // If any cookies violate the new uniqueness constraints (no two
+-    // cookies with the same (name, domain, path)) erase the cookie store.
+-    // That "shouldn't happen", which means probably not too many users'
+-    // cookie stores will have it.
+-    // The choice to drop rather than pick one of the cookies randomly is
+-    // because it is expected that servers will be able to deal with a known
+-    // state (no cookies == first visit), and there may be cookie values they
+-    // may not be able to deal with.
++    // cookies with the same (name, domain, path)), pick the newer version,
++    // since that's what CookieMonster would do anyway.
+     if (!db_->Execute(
+-            "INSERT OR FAIL INTO cookies "
++            "INSERT OR REPLACE INTO cookies "
+             "(creation_utc, host_key, name, value, path, expires_utc, "
+             "is_secure, is_httponly, last_access_utc, has_expires, "
+             "is_persistent, priority, encrypted_value, firstpartyonly) "
+             "SELECT creation_utc, host_key, name, value, path, expires_utc, "
+             "       secure, httponly, last_access_utc, has_expires, "
+             "       persistent, priority, encrypted_value, firstpartyonly "
+-            "FROM cookies_old")) {
+-      // The old database had duplicate cookies in a way that violates
+-      // the spec.  Treat that as DB corruption and start with a clean slate.
+-      if (!db_->Execute("DELETE FROM COOKIES;"))
+-        return false;
++            "FROM cookies_old ORDER BY creation_utc ASC")) {
++      return false;
+     }
+     if (!db_->Execute("DROP TABLE cookies_old"))
+       return false;

--- a/vsts.yml
+++ b/vsts.yml
@@ -109,7 +109,8 @@ phases:
       testRunTitle: 'Libchromiumcontent Tests'
     condition: and(always(), eq(variables['Build.Reason'], 'Schedule'), eq(variables['COMPONENT'], 'static_library'))
 
-  - task: AmazonWebServices.aws-vsts-tools.S3Upload.S3Upload@1
+  - task: S3Upload@1
+    displayName: 'Upload artifacts to S3'
     inputs:
       awsCredentials: 'Libchromium Content S3'
       regionName: 'us-east-1'

--- a/vsts.yml
+++ b/vsts.yml
@@ -54,7 +54,7 @@ phases:
      fi
     name: Update
 
-  - task: AmazonWebServices.aws-vsts-tools.S3Upload.S3Upload@1
+  - task: S3Upload@1
     inputs:
       awsCredentials: 'Libchromium Content S3'
       regionName: 'us-east-1'


### PR DESCRIPTION
…ion on V9->V10 migration

##### Description of Change
<!-- Describe your PR here, in enough detail that a reviewer can understand its purpose easily. -->

https://chromium-review.googlesource.com/c/chromium/src/+/1097204
The change landed in `69.0.3460.0`, so there's no need to backport it to any other branch.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] Patch information is added to appropriate `.patches.yaml`
- [x] `script/update` runs without error
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)