### PR TITLE
build: fix native_mksnapshot magic number mismatch (3-0-x)

### DIFF
--- a/chromiumcontent/args/native_mksnapshot.gn
+++ b/chromiumcontent/args/native_mksnapshot.gn
@@ -3,7 +3,6 @@ is_component_build = false
 is_debug = false
 enable_linux_installer = false
 v8_use_snapshot = true
-v8_enable_i18n_support = false
 enable_nacl = false
 if (target_cpu == "arm") {
   v8_snapshot_toolchain="//build/toolchain/linux:clang_arm"


### PR DESCRIPTION
##### Description of Change
This PR fixes electron/electron#15312 for 3-0-x.  Setting `v8_enable_i18n_support = false` was causing the following error when using snapshots generated from arm/arm64 native mksnapshot binaries:
```
#
# Fatal error in ../../v8/src/snapshot/deserializer.cc, line 79
# Check failed: magic_number_ == SerializedData::ComputeMagicNumber(external_reference_table_).
#
Illegal instruction
```

v8_enable_i18n_support = false was originally set to false because when we added native mksnapshot binaries for arm in 1-8-x running those binaries caused an error about a missing shared library, `libicui18n.so`.  However in setting this flag to false the snapshots generated have a non matching magic number to what Electron expects because Electron is (and should be) built with `v8_enable_i18n_support = true`.  In 3-0-x the `libicui18n.so` issue doesn't exist, so its safe to change this flag.
<!-- Describe your PR here, in enough detail that a reviewer can understand its purpose easily. -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `script/update` runs without error
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)