### PR TITLE
build: fix native_mksnapshot magic number mismatch (2-0-x)

### DIFF
--- a/chromiumcontent/BUILD.gn
+++ b/chromiumcontent/BUILD.gn
@@ -394,6 +394,12 @@ if (is_electron_build && !is_component_build) {
     deps = [ ":targets" ]
   }
 
+  group("native_mksnapshot") {
+    deps = [
+      "//v8:v8_maybe_snapshot"
+    ]
+  }
+
 }
 
 # There are some executable targets whose products are ran during build.

--- a/chromiumcontent/args/native_mksnapshot.gn
+++ b/chromiumcontent/args/native_mksnapshot.gn
@@ -1,10 +1,9 @@
-root_extra_deps = [ "//v8:v8_maybe_snapshot" ]
-is_electron_build = true
+root_extra_deps = [ "//v8:v8_maybe_snapshot", "//chromiumcontent:chromiumcontent" ]
 is_component_build = false
 is_debug = false
 enable_linux_installer = false
 v8_use_snapshot = true
-v8_enable_i18n_support = false
+enable_nacl = false
 if (target_cpu == "arm") {
   v8_snapshot_toolchain="//build/toolchain/linux:clang_arm"
 }

--- a/patches/v8/028-native_mksnapshot.patch
+++ b/patches/v8/028-native_mksnapshot.patch
@@ -1,0 +1,25 @@
+diff --git a/BUILD.gn b/BUILD.gn
+index 494ba22..894797c 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -907,9 +907,19 @@ if (v8_use_external_startup_data) {
+     ]
+     public_deps = [
+       ":natives_blob",
+-      ":run_mksnapshot",
+     ]
+ 
++    if (v8_snapshot_toolchain == "//build/toolchain/linux:clang_arm" ||
++        v8_snapshot_toolchain == "//build/toolchain/linux:clang_arm64") {
++      public_deps += [
++        ":mksnapshot($v8_snapshot_toolchain)",
++      ]
++    } else {
++      public_deps += [
++        ":run_mksnapshot",
++      ]
++    }
++
+     sources = [
+       "src/setup-isolate-deserialize.cc",
+       "src/snapshot/natives-external.cc",

--- a/script/build
+++ b/script/build
@@ -67,7 +67,7 @@ def main():
     out_dir = get_output_dir(SOURCE_ROOT, target_arch, component)
     target = 'chromiumcontent:chromiumcontent'
     if component == 'native_mksnapshot':
-      target = 'v8:mksnapshot'
+      target = 'chromiumcontent:native_mksnapshot'
     subprocess.check_call([NINJA, '-C', os.path.relpath(out_dir), target], env=env)
     if component == 'static_library':
       subenv = env.copy()


### PR DESCRIPTION
##### Description of Change
Backports #729 to 2-0-x.  Fixes electron/electron#15312 for 2-0-x. 
<!-- Describe your PR here, in enough detail that a reviewer can understand its purpose easily. -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `script/update` runs without error
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)