### PR TITLE
fix: update more api under //sql for 3.26 (2-0-x)

### DIFF
--- a/patches/099-sqlite_api_3_26_0.patch
+++ b/patches/099-sqlite_api_3_26_0.patch
@@ -4,9 +4,26 @@ Date: Thu, 13 Dec 2018 04:13:40 +0530
 Subject: sqlite: Update api in //sql and //third_party/WebKit
 
 Refs https://chromium-review.googlesource.com/c/chromium/src/+/1352694
+Refs https://chromium-review.googlesource.com/c/chromium/src/+/1146280
+Refs https://chromium-review.googlesource.com/c/chromium/src/+/1357825
+Refs https://chromium-review.googlesource.com/c/chromium/src/+/1343789
+Refs https://chromium-review.googlesource.com/c/chromium/src/+/1146295
+Refs https://chromium-review.googlesource.com/c/chromium/src/+/1146768
 
+diff --git a/components/password_manager/core/browser/login_database.cc b/components/password_manager/core/browser/login_database.cc
+index e7726d2484b7..1c1d21358c6c 100644
+--- a/components/password_manager/core/browser/login_database.cc
++++ b/components/password_manager/core/browser/login_database.cc
+@@ -532,7 +532,6 @@ bool LoginDatabase::Init() {
+   db_.set_page_size(2048);
+   db_.set_cache_size(32);
+   db_.set_exclusive_locking();
+-  db_.set_restrict_to_user();
+   db_.set_histogram_tag("Passwords");
+ 
+   if (!db_.Open(db_path_)) {
 diff --git a/content/browser/dom_storage/dom_storage_database.cc b/content/browser/dom_storage/dom_storage_database.cc
-index 2f47c3af03e5262bf6a2588fc1b05b7b1ec604d1..2bfc5fc3a2108001e43702c24cdb20dd5b033320 100644
+index 2f47c3af03e5..2bfc5fc3a210 100644
 --- a/content/browser/dom_storage/dom_storage_database.cc
 +++ b/content/browser/dom_storage/dom_storage_database.cc
 @@ -200,12 +200,8 @@ bool DOMStorageDatabase::LazyOpen(bool create_if_needed) {
@@ -79,15 +96,16 @@ index 2f47c3af03e5262bf6a2588fc1b05b7b1ec604d1..2bfc5fc3a2108001e43702c24cdb20dd
    db_.reset(NULL);
  }
 diff --git a/content/browser/dom_storage/dom_storage_database.h b/content/browser/dom_storage/dom_storage_database.h
-index 9f5fd4a61be6e8426e0857e0f7c1b5a3d5324810..bcf8a3ba713989f51eaa191acc30103c8cef57fe 100644
+index 9f5fd4a61be6..b5d2d9b7006c 100644
 --- a/content/browser/dom_storage/dom_storage_database.h
 +++ b/content/browser/dom_storage/dom_storage_database.h
-@@ -80,8 +80,10 @@ class CONTENT_EXPORT DOMStorageDatabase {
+@@ -80,8 +80,11 @@ class CONTENT_EXPORT DOMStorageDatabase {
  
    enum SchemaVersion {
      INVALID,
 -    V1,
 -    V2
++
 +    // V1 is deprecated.
 +
 +    // 2011-07-15 - https://bugs.webkit.org/show_bug.cgi?id=58762
@@ -95,7 +113,7 @@ index 9f5fd4a61be6e8426e0857e0f7c1b5a3d5324810..bcf8a3ba713989f51eaa191acc30103c
    };
  
    // Open the database at file_path_ if it exists already and creates it if
-@@ -105,12 +107,6 @@ class CONTENT_EXPORT DOMStorageDatabase {
+@@ -105,12 +108,6 @@ class CONTENT_EXPORT DOMStorageDatabase {
    // scratch.
    bool DeleteFileAndRecreate();
  
@@ -108,11 +126,322 @@ index 9f5fd4a61be6e8426e0857e0f7c1b5a3d5324810..bcf8a3ba713989f51eaa191acc30103c
    void Close();
    bool IsOpen() const { return db_.get() ? db_->is_open() : false; }
  
+diff --git a/content/browser/dom_storage/dom_storage_database_unittest.cc b/content/browser/dom_storage/dom_storage_database_unittest.cc
+index 54f9e382b96f..a402b2626fb1 100644
+--- a/content/browser/dom_storage/dom_storage_database_unittest.cc
++++ b/content/browser/dom_storage/dom_storage_database_unittest.cc
+@@ -18,15 +18,6 @@ using base::ASCIIToUTF16;
+ 
+ namespace content {
+ 
+-void CreateV1Table(sql::Connection* db) {
+-  ASSERT_TRUE(db->is_open());
+-  ASSERT_TRUE(db->Execute("DROP TABLE IF EXISTS ItemTable"));
+-  ASSERT_TRUE(db->Execute(
+-      "CREATE TABLE ItemTable ("
+-      "key TEXT UNIQUE ON CONFLICT REPLACE, "
+-      "value TEXT NOT NULL ON CONFLICT FAIL)"));
+-}
+-
+ void CreateV2Table(sql::Connection* db) {
+   ASSERT_TRUE(db->is_open());
+   ASSERT_TRUE(db->Execute("DROP TABLE IF EXISTS ItemTable"));
+@@ -36,37 +27,15 @@ void CreateV2Table(sql::Connection* db) {
+       "value BLOB NOT NULL ON CONFLICT FAIL)"));
+ }
+ 
+-void CreateInvalidKeyColumnTable(sql::Connection* db) {
+-  // Create a table with the key type as FLOAT - this is "invalid"
++void CreateInvalidTable(sql::Connection* db) {
++  // Create a table with out a key column - this is "invalid"
+   // as far as the DOM Storage db is concerned.
+   ASSERT_TRUE(db->is_open());
+   ASSERT_TRUE(db->Execute("DROP TABLE IF EXISTS ItemTable"));
+   ASSERT_TRUE(db->Execute(
+       "CREATE TABLE IF NOT EXISTS ItemTable ("
+-      "key FLOAT UNIQUE ON CONFLICT REPLACE, "
+       "value BLOB NOT NULL ON CONFLICT FAIL)"));
+ }
+-void CreateInvalidValueColumnTable(sql::Connection* db) {
+-  // Create a table with the value type as FLOAT - this is "invalid"
+-  // as far as the DOM Storage db is concerned.
+-  ASSERT_TRUE(db->is_open());
+-  ASSERT_TRUE(db->Execute("DROP TABLE IF EXISTS ItemTable"));
+-  ASSERT_TRUE(db->Execute(
+-      "CREATE TABLE IF NOT EXISTS ItemTable ("
+-      "key TEXT UNIQUE ON CONFLICT REPLACE, "
+-      "value FLOAT NOT NULL ON CONFLICT FAIL)"));
+-}
+-
+-void InsertDataV1(sql::Connection* db,
+-                  const base::string16& key,
+-                  const base::string16& value) {
+-  sql::Statement statement(db->GetCachedStatement(SQL_FROM_HERE,
+-      "INSERT INTO ItemTable VALUES (?,?)"));
+-  statement.BindString16(0, key);
+-  statement.BindString16(1, value);
+-  ASSERT_TRUE(statement.is_valid());
+-  statement.Run();
+-}
+ 
+ void CheckValuesMatch(DOMStorageDatabase* db,
+                       const DOMStorageValuesMap& expected) {
+@@ -201,39 +170,13 @@ TEST(DOMStorageDatabaseTest, TestDetectSchemaVersion) {
+   db.db_.reset(new sql::Connection());
+   ASSERT_TRUE(db.db_->OpenInMemory());
+ 
+-  CreateInvalidValueColumnTable(db.db_.get());
++  CreateInvalidTable(db.db_.get());
+   EXPECT_EQ(DOMStorageDatabase::INVALID, db.DetectSchemaVersion());
+ 
+-  CreateInvalidKeyColumnTable(db.db_.get());
+-  EXPECT_EQ(DOMStorageDatabase::INVALID, db.DetectSchemaVersion());
+-
+-  CreateV1Table(db.db_.get());
+-  EXPECT_EQ(DOMStorageDatabase::V1, db.DetectSchemaVersion());
+-
+   CreateV2Table(db.db_.get());
+   EXPECT_EQ(DOMStorageDatabase::V2, db.DetectSchemaVersion());
+ }
+ 
+-TEST(DOMStorageDatabaseTest, TestLazyOpenUpgradesDatabase) {
+-  // This test needs to operate with a file on disk so that we
+-  // can create a table at version 1 and then close it again
+-  // so that LazyOpen sees there is work to do (LazyOpen will return
+-  // early if the database is already open).
+-  base::ScopedTempDir temp_dir;
+-  ASSERT_TRUE(temp_dir.CreateUniqueTempDir());
+-  base::FilePath file_name =
+-      temp_dir.GetPath().AppendASCII("TestDOMStorageDatabase.db");
+-
+-  DOMStorageDatabase db(file_name);
+-  db.db_.reset(new sql::Connection());
+-  ASSERT_TRUE(db.db_->Open(file_name));
+-  CreateV1Table(db.db_.get());
+-  db.Close();
+-
+-  EXPECT_TRUE(db.LazyOpen(true));
+-  EXPECT_EQ(DOMStorageDatabase::V2, db.DetectSchemaVersion());
+-}
+-
+ TEST(DOMStorageDatabaseTest, SimpleWriteAndReadBack) {
+   DOMStorageDatabase db;
+ 
+@@ -266,25 +209,6 @@ TEST(DOMStorageDatabaseTest, WriteWithClear) {
+   CheckValuesMatch(&db, storage);
+ }
+ 
+-TEST(DOMStorageDatabaseTest, UpgradeFromV1ToV2WithData) {
+-  const base::string16 kCannedKey = ASCIIToUTF16("foo");
+-  const base::NullableString16 kCannedValue(ASCIIToUTF16("bar"), false);
+-  DOMStorageValuesMap expected;
+-  expected[kCannedKey] = kCannedValue;
+-
+-  DOMStorageDatabase db;
+-  db.db_.reset(new sql::Connection());
+-  ASSERT_TRUE(db.db_->OpenInMemory());
+-  CreateV1Table(db.db_.get());
+-  InsertDataV1(db.db_.get(), kCannedKey, kCannedValue.string());
+-
+-  ASSERT_TRUE(db.UpgradeVersion1To2());
+-
+-  EXPECT_EQ(DOMStorageDatabase::V2, db.DetectSchemaVersion());
+-
+-  CheckValuesMatch(&db, expected);
+-}
+-
+ TEST(DOMStorageDatabaseTest, TestSimpleRemoveOneValue) {
+   DOMStorageDatabase db;
+ 
+diff --git a/sql/BUILD.gn b/sql/BUILD.gn
+index 42fa3de8359a..3b4bda22a56c 100644
+--- a/sql/BUILD.gn
++++ b/sql/BUILD.gn
+@@ -13,6 +13,7 @@ component("sql") {
+     "error_delegate_util.cc",
+     "error_delegate_util.h",
+     "init_status.h",
++    "internal_api_token.h",
+     "meta_table.cc",
+     "meta_table.h",
+     "recovery.cc",
 diff --git a/sql/connection.cc b/sql/connection.cc
-index d7477f57dbfca926fb8c8c78c63cb02a810e5c05..42b051da326d64d2f9fc920975a2831692ad7afe 100644
+index d7477f57dbfc..d9e24556c547 100644
 --- a/sql/connection.cc
 +++ b/sql/connection.cc
-@@ -1705,9 +1705,17 @@ bool Connection::OpenInternal(const std::string& file_name,
+@@ -274,6 +274,21 @@ bool StatementID::operator<(const StatementID& other) const {
+   return strcmp(str_, other.str_) < 0;
+ }
+ 
++// static
++base::FilePath Connection::JournalPath(const base::FilePath& db_path) {
++  return base::FilePath(db_path.value() + FILE_PATH_LITERAL("-journal"));
++}
++
++// static
++base::FilePath Connection::WriteAheadLogPath(const base::FilePath& db_path) {
++  return base::FilePath(db_path.value() + FILE_PATH_LITERAL("-wal"));
++}
++
++// static
++base::FilePath Connection::SharedMemoryFilePath(const base::FilePath& db_path) {
++  return base::FilePath(db_path.value() + FILE_PATH_LITERAL("-shm"));
++}
++
+ Connection::StatementRef::StatementRef(Connection* connection,
+                                        sqlite3_stmt* stmt,
+                                        bool was_valid)
+@@ -310,13 +325,18 @@ void Connection::StatementRef::Close(bool forced) {
+   // previously held for this ref.
+   was_valid_ = was_valid_ && forced;
+ }
++ 
++static_assert(
++    Connection::kDefaultPageSize == SQLITE_DEFAULT_PAGE_SIZE,
++    "Connection::kDefaultPageSize must match the value configured into SQLite");
++
++constexpr int Connection::kDefaultPageSize;
+ 
+ Connection::Connection()
+     : db_(NULL),
+-      page_size_(0),
++      page_size_(kDefaultPageSize),
+       cache_size_(0),
+       exclusive_locking_(false),
+-      restrict_to_user_(false),
+       transaction_nesting_(0),
+       needs_rollback_(false),
+       in_memory_(false),
+@@ -492,9 +512,12 @@ void Connection::Preload() {
+     return;
+   }
+ 
++  // The constructor and set_page_size() ensure that page_size_ is never zero.
++  const int page_size = page_size_;
++  DCHECK(page_size);
++
+   // Use local settings if provided, otherwise use documented defaults.  The
+   // actual results could be fetching via PRAGMA calls.
+-  const int page_size = page_size_ ? page_size_ : 1024;
+   sqlite3_int64 preload_size = page_size * (cache_size_ ? cache_size_ : 2000);
+   if (preload_size < 1)
+     return;
+@@ -635,8 +658,7 @@ bool Connection::RegisterIntentToUpload() const {
+   // Put the collection of diagnostic data next to the databases.  In most
+   // cases, this is the profile directory, but safe-browsing stores a Cookies
+   // file in the directory above the profile directory.
+-  base::FilePath breadcrumb_path(
+-      db_path.DirName().Append(FILE_PATH_LITERAL("sqlite-diag")));
++  base::FilePath breadcrumb_path = db_path.DirName().AppendASCII("sqlite-diag");
+ 
+   // Lock against multiple updates to the diagnostics file.  This code should
+   // seldom be called in the first place, and when called it should seldom be
+@@ -1069,17 +1091,9 @@ bool Connection::Raze() {
+     return false;
+   }
+ 
+-  if (page_size_) {
+-    // Enforce SQLite restrictions on |page_size_|.
+-    DCHECK(!(page_size_ & (page_size_ - 1)))
+-        << " page_size_ " << page_size_ << " is not a power of two.";
+-    const int kSqliteMaxPageSize = 32768;  // from sqliteLimit.h
+-    DCHECK_LE(page_size_, kSqliteMaxPageSize);
+-    const std::string sql =
+-        base::StringPrintf("PRAGMA page_size=%d", page_size_);
+-    if (!null_db.Execute(sql.c_str()))
+-      return false;
+-  }
++  const std::string sql = base::StringPrintf("PRAGMA page_size=%d", page_size_);
++  if (!null_db.Execute(sql.c_str()))
++    return false;
+ 
+ #if defined(OS_ANDROID)
+   // Android compiles with SQLITE_DEFAULT_AUTOVACUUM.  Unfortunately,
+@@ -1231,8 +1245,8 @@ void Connection::Poison() {
+ bool Connection::Delete(const base::FilePath& path) {
+   base::ThreadRestrictions::AssertIOAllowed();
+ 
+-  base::FilePath journal_path(path.value() + FILE_PATH_LITERAL("-journal"));
+-  base::FilePath wal_path(path.value() + FILE_PATH_LITERAL("-wal"));
++  base::FilePath journal_path = Connection::JournalPath(path);
++  base::FilePath wal_path = Connection::WriteAheadLogPath(path);
+ 
+   std::string journal_str = AsUTF8ForSQL(journal_path);
+   std::string wal_str = AsUTF8ForSQL(wal_path);
+@@ -1257,16 +1271,13 @@ bool Connection::Delete(const base::FilePath& path) {
+   vfs->xDelete(vfs, path_str.c_str(), 0);
+ 
+   int journal_exists = 0;
+-  vfs->xAccess(vfs, journal_str.c_str(), SQLITE_ACCESS_EXISTS,
+-               &journal_exists);
++  vfs->xAccess(vfs, journal_str.c_str(), SQLITE_ACCESS_EXISTS, &journal_exists);
+ 
+   int wal_exists = 0;
+-  vfs->xAccess(vfs, wal_str.c_str(), SQLITE_ACCESS_EXISTS,
+-               &wal_exists);
++  vfs->xAccess(vfs, wal_str.c_str(), SQLITE_ACCESS_EXISTS, &wal_exists);
+ 
+   int path_exists = 0;
+-  vfs->xAccess(vfs, path_str.c_str(), SQLITE_ACCESS_EXISTS,
+-               &path_exists);
++  vfs->xAccess(vfs, path_str.c_str(), SQLITE_ACCESS_EXISTS, &path_exists);
+ 
+   return !journal_exists && !wal_exists && !path_exists;
+ }
+@@ -1352,7 +1363,8 @@ void Connection::RollbackAllTransactions() {
+ }
+ 
+ bool Connection::AttachDatabase(const base::FilePath& other_db_path,
+-                                const char* attachment_point) {
++                                const char* attachment_point,
++                                InternalApiToken) {
+   DCHECK(ValidAttachmentPoint(attachment_point));
+ 
+   Statement s(GetUniqueStatement("ATTACH DATABASE ? AS ?"));
+@@ -1365,7 +1377,8 @@ bool Connection::AttachDatabase(const base::FilePath& other_db_path,
+   return s.Run();
+ }
+ 
+-bool Connection::DetachDatabase(const char* attachment_point) {
++bool Connection::DetachDatabase(const char* attachment_point,
++                                InternalApiToken) {
+   DCHECK(ValidAttachmentPoint(attachment_point));
+ 
+   Statement s(GetUniqueStatement("DETACH DATABASE ?"));
+@@ -1597,23 +1610,15 @@ bool Connection::DoesSchemaItemExist(
+ 
+ bool Connection::DoesColumnExist(const char* table_name,
+                                  const char* column_name) const {
+-  std::string sql("PRAGMA TABLE_INFO(");
+-  sql.append(table_name);
+-  sql.append(")");
+-
+-  Statement statement(GetUntrackedStatement(sql.c_str()));
+-
+-  // This can happen if the database is corrupt and the error is a test
+-  // expectation.
+-  if (!statement.is_valid())
+-    return false;
+-
+-  while (statement.Step()) {
+-    if (base::EqualsCaseInsensitiveASCII(statement.ColumnString(1),
+-                                         column_name))
+-      return true;
+-  }
+-  return false;
++  // sqlite3_table_column_metadata uses out-params to return column definition
++  // details, such as the column type and whether it allows NULL values. These
++  // aren't needed to compute the current method's result, so we pass in nullptr
++  // for all the out-params.
++  int error = sqlite3_table_column_metadata(
++      db_, "main", table_name, column_name, /* pzDataType= */ nullptr,
++      /* pzCollSeq= */ nullptr, /* pNotNull= */ nullptr,
++      /* pPrimaryKey= */ nullptr, /* pAutoinc= */ nullptr);
++  return error == SQLITE_OK;
+ }
+ 
+ int64_t Connection::GetLastInsertRowId() const {
+@@ -1705,9 +1710,17 @@ bool Connection::OpenInternal(const std::string& file_name,
    // Custom memory-mapping VFS which reads pages using regular I/O on first hit.
    sqlite3_vfs* vfs = VFSWrapper();
    const char* vfs_name = (vfs ? vfs->zName : nullptr);
@@ -133,21 +462,650 @@ index d7477f57dbfca926fb8c8c78c63cb02a810e5c05..42b051da326d64d2f9fc920975a28316
    if (err != SQLITE_OK) {
      // Extended error codes cannot be enabled until a handle is
      // available, fetch manually.
+@@ -1726,30 +1739,6 @@ bool Connection::OpenInternal(const std::string& file_name,
+     return false;
+   }
+ 
+-  // TODO(shess): OS_WIN support?
+-#if defined(OS_POSIX) && !defined(OS_FUCHSIA)
+-  if (restrict_to_user_) {
+-    DCHECK_NE(file_name, std::string(":memory"));
+-    base::FilePath file_path(file_name);
+-    int mode = 0;
+-    // TODO(shess): Arguably, failure to retrieve and change
+-    // permissions should be fatal if the file exists.
+-    if (base::GetPosixFilePermissions(file_path, &mode)) {
+-      mode &= base::FILE_PERMISSION_USER_MASK;
+-      base::SetPosixFilePermissions(file_path, mode);
+-
+-      // SQLite sets the permissions on these files from the main
+-      // database on create.  Set them here in case they already exist
+-      // at this point.  Failure to set these permissions should not
+-      // be fatal unless the file doesn't exist.
+-      base::FilePath journal_path(file_name + FILE_PATH_LITERAL("-journal"));
+-      base::FilePath wal_path(file_name + FILE_PATH_LITERAL("-wal"));
+-      base::SetPosixFilePermissions(journal_path, mode);
+-      base::SetPosixFilePermissions(wal_path, mode);
+-    }
+-  }
+-#endif  // defined(OS_POSIX) && !defined(OS_FUCHSIA)
+-
+   // SQLite uses a lookaside buffer to improve performance of small mallocs.
+   // Chromium already depends on small mallocs being efficient, so we disable
+   // this to avoid the extra memory overhead.
+@@ -1821,16 +1810,8 @@ bool Connection::OpenInternal(const std::string& file_name,
+   const base::TimeDelta kBusyTimeout =
+     base::TimeDelta::FromSeconds(kBusyTimeoutSeconds);
+ 
+-  if (page_size_ != 0) {
+-    // Enforce SQLite restrictions on |page_size_|.
+-    DCHECK(!(page_size_ & (page_size_ - 1)))
+-        << " page_size_ " << page_size_ << " is not a power of two.";
+-    const int kSqliteMaxPageSize = 32768;  // from sqliteLimit.h
+-    DCHECK_LE(page_size_, kSqliteMaxPageSize);
+-    const std::string sql =
+-        base::StringPrintf("PRAGMA page_size=%d", page_size_);
+-    ignore_result(ExecuteWithTimeout(sql.c_str(), kBusyTimeout));
+-  }
++  const std::string sql = base::StringPrintf("PRAGMA page_size=%d", page_size_);
++  ignore_result(ExecuteWithTimeout(sql.c_str(), kBusyTimeout));
+ 
+   if (cache_size_ != 0) {
+     const std::string sql =
+diff --git a/sql/connection.h b/sql/connection.h
+index 8b9640785e98..7d936384ca65 100644
+--- a/sql/connection.h
++++ b/sql/connection.h
+@@ -36,7 +36,6 @@ class ProcessMemoryDump;
+ namespace sql {
+ 
+ class ConnectionMemoryDumpProvider;
+-class Recovery;
+ class Statement;
+ 
+ // To allow some test classes to be friended.
+@@ -93,7 +92,10 @@ class StatementID {
+ 
+ #define SQL_FROM_HERE sql::StatementID(__FILE__, __LINE__)
+ 
+-class Connection;
++// Exposes private Connection functionality to unit tests.
++//
++// This class is only defined in test targets.
++class ConnectionTestPeer;
+ 
+ // Abstract the source of timing information for metrics (RecordCommitTime, etc)
+ // to allow testing control.
+@@ -124,11 +126,20 @@ class SQL_EXPORT Connection {
+   // Sets the page size that will be used when creating a new database. This
+   // must be called before Init(), and will only have an effect on new
+   // databases.
+-  //
+-  // From sqlite.org: "The page size must be a power of two greater than or
+-  // equal to 512 and less than or equal to SQLITE_MAX_PAGE_SIZE. The maximum
+-  // value for SQLITE_MAX_PAGE_SIZE is 32768."
+-  void set_page_size(int page_size) { page_size_ = page_size; }
++  // The page size must be a power of two between 512 and 65536 inclusive.
++  void set_page_size(int page_size) {
++    DCHECK(!page_size || (page_size >= 512));
++    DCHECK(!page_size || !(page_size & (page_size - 1)))
++    DCHECK_GE(page_size, 512);
++    DCHECK_LE(page_size, 65536);
++    DCHECK(!(page_size & (page_size - 1)))
++        << "page_size must be a power of two";
++
++    page_size_ = page_size;
++  }
++
++  // The page size that will be used when creating a new database.
++  int page_size() const { return page_size_; }
+ 
+   // Sets the number of pages that will be cached in memory by sqlite. The
+   // total cache size in bytes will be page_size * cache_size. This must be
+@@ -147,12 +158,6 @@ class SQL_EXPORT Connection {
+   // This must be called before Open() to have an effect.
+   void set_exclusive_locking() { exclusive_locking_ = true; }
+ 
+-  // Call to cause Open() to restrict access permissions of the
+-  // database file to only the owner.
+-  // TODO(shess): Currently only supported on OS_POSIX, is a noop on
+-  // other platforms.
+-  void set_restrict_to_user() { restrict_to_user_ = true; }
+-
+   // Call to use alternative status-tracking for mmap.  Usually this is tracked
+   // in the meta table, but some databases have no meta table.
+   // TODO(shess): Maybe just have all databases use the alt option?
+@@ -387,16 +392,21 @@ class SQL_EXPORT Connection {
+ 
+   // Attached databases---------------------------------------------------------
+ 
+-  // SQLite supports attaching multiple database files to a single
+-  // handle.  Attach the database in |other_db_path| to the current
+-  // handle under |attachment_point|.  |attachment_point| should only
+-  // contain characters from [a-zA-Z0-9_].
++  // SQLite supports attaching multiple database files to a single connection.
++  //
++  // Attach the database in |other_db_path| to the current connection under
++  // |attachment_point|. |attachment_point| must only contain characters from
++  // [a-zA-Z0-9_].
+   //
+   // Note that calling attach or detach with an open transaction is an
+   // error.
++  //
++  // These APIs are only exposed for use in recovery. They are extremely subtle
++  // and are not useful for features built on top of //sql.
+   bool AttachDatabase(const base::FilePath& other_db_path,
+-                      const char* attachment_point);
+-  bool DetachDatabase(const char* attachment_point);
++                      const char* attachment_point,
++                      InternalApiToken);
++  bool DetachDatabase(const char* attachment_point, InternalApiToken);
+ 
+   // Statements ----------------------------------------------------------------
+ 
+@@ -466,6 +476,12 @@ class SQL_EXPORT Connection {
+   bool DoesViewExist(const char* table_name) const;
+ 
+   // Returns true if a column with the given name exists in the given table.
++  //
++  // Calling this method on a VIEW returns an unspecified result.
++  //
++  // This should only be used by migration code for legacy features that do not
++  // use MetaTable, and need an alternative way of figuring out the database's
++  // current version.
+   bool DoesColumnExist(const char* table_name, const char* column_name) const;
+ 
+   // Returns sqlite's internal ID for the last inserted row. Valid only
+@@ -507,10 +523,49 @@ class SQL_EXPORT Connection {
+   // crash server.
+   void ReportDiagnosticInfo(int extended_error, Statement* stmt);
+ 
+- private:
+-  // For recovery module.
+-  friend class Recovery;
++  // Computes the path of a database's rollback journal.
++  //
++  // The journal file is created at the beginning of the database's first
++  // transaction. The file may be removed and re-created between transactions,
++  // depending on whether the database is opened in exclusive mode, and on
++  // configuration options. The journal file does not exist when the database
++  // operates in WAL mode.
++  //
++  // This is intended for internal use and tests. To preserve our ability to
++  // iterate on our SQLite configuration, features must avoid relying on
++  // the existence of specific files.
++  static base::FilePath JournalPath(const base::FilePath& db_path);
+ 
++  // Computes the path of a database's write-ahead log (WAL).
++  //
++  // The WAL file exists while a database is opened in WAL mode.
++  //
++  // This is intended for internal use and tests. To preserve our ability to
++  // iterate on our SQLite configuration, features must avoid relying on
++  // the existence of specific files.
++  static base::FilePath WriteAheadLogPath(const base::FilePath& db_path);
++
++  // Computes the path of a database's shared memory (SHM) file.
++  //
++  // The SHM file is used to coordinate between multiple processes using the
++  // same database in WAL mode. Thus, this file only exists for databases using
++  // WAL and not opened in exclusive mode.
++  //
++  // This is intended for internal use and tests. To preserve our ability to
++  // iterate on our SQLite configuration, features must avoid relying on
++  // the existence of specific files.
++  static base::FilePath SharedMemoryFilePath(const base::FilePath& db_path);
++
++  // Default page size for newly created databases.
++  //
++  // Guaranteed to match SQLITE_DEFAULT_PAGE_SIZE.
++  static constexpr int kDefaultPageSize = 4096;
++
++  // Internal state accessed by other classes in //sql.
++  sqlite3* db(InternalApiToken) const { return db_; }
++  bool poisoned(InternalApiToken) const { return poisoned_; }
++
++ private:
+   // Allow test-support code to set/reset error expecter.
+   friend class test::ScopedErrorExpecter;
+ 
+@@ -518,6 +573,8 @@ class SQL_EXPORT Connection {
+   // (they should go through Statement).
+   friend class Statement;
+ 
++  friend class ConnectionTestPeer;
++
+   friend class test::ScopedCommitHook;
+   friend class test::ScopedScalarFunction;
+   friend class test::ScopedMockTimeSource;
+@@ -753,7 +810,6 @@ class SQL_EXPORT Connection {
+   int page_size_;
+   int cache_size_;
+   bool exclusive_locking_;
+-  bool restrict_to_user_;
+ 
+   // All cached statements. Keeping a reference to these statements means that
+   // they'll remain active. Using flat_map here because number of cached
+diff --git a/sql/connection_unittest.cc b/sql/connection_unittest.cc
+index 4ee8b0288a35..b1aeabd6fa91 100644
+--- a/sql/connection_unittest.cc
++++ b/sql/connection_unittest.cc
+@@ -30,6 +30,20 @@
+ #endif
+ 
+ namespace sql {
++
++class ConnectionTestPeer {
++ public:
++  static bool AttachDatabase(Connection* db,
++                             const base::FilePath& other_db_path,
++                             const char* attachment_point) {
++    return db->AttachDatabase(other_db_path, attachment_point,
++                              InternalApiToken());
++  }
++  static bool DetachDatabase(Connection* db, const char* attachment_point) {
++    return db->DetachDatabase(attachment_point, InternalApiToken());
++  }
++};
++
+ namespace test {
+ 
+ // Replaces the database time source with an object that steps forward 1ms on
+@@ -565,11 +579,7 @@ TEST_F(SQLConnectionTest, RazePageSize) {
+   const std::string default_page_size =
+       ExecuteWithResult(&db(), "PRAGMA page_size");
+ 
+-  // The database should have the default page size after raze.
+-  EXPECT_NO_FATAL_FAILURE(
+-      TestPageSize(db_path(), 0, default_page_size, 0, default_page_size));
+-
+-  // Sync user 32k pages.
++  // Sync uses 32k pages.
+   EXPECT_NO_FATAL_FAILURE(
+       TestPageSize(db_path(), 32768, "32768", 32768, "32768"));
+ 
+@@ -582,11 +592,12 @@ TEST_F(SQLConnectionTest, RazePageSize) {
+   EXPECT_NO_FATAL_FAILURE(
+       TestPageSize(db_path(), 2048, "2048", 4096, "4096"));
+ 
+-  // Databases with no page size specified should result in the new default
++  // Databases with no page size specified should result in the default
+   // page size.  2k has never been the default page size.
+   ASSERT_NE("2048", default_page_size);
+-  EXPECT_NO_FATAL_FAILURE(
+-      TestPageSize(db_path(), 2048, "2048", 0, default_page_size));
++  EXPECT_NO_FATAL_FAILURE(TestPageSize(db_path(), 2048, "2048",
++                                       Connection::kDefaultPageSize,
++                                       default_page_size));
+ }
+ 
+ // Test that Raze() results are seen in other connections.
+@@ -903,86 +914,76 @@ TEST_F(SQLConnectionTest, SetTempDirForSQL) {
+ }
+ #endif
+ 
+-TEST_F(SQLConnectionTest, Delete) {
++TEST_F(SQLConnectionTest, DeleteNonWal) {
+   EXPECT_TRUE(db().Execute("CREATE TABLE x (x)"));
+   db().Close();
+ 
+   // Should have both a main database file and a journal file because
+   // of journal_mode TRUNCATE.
+-  base::FilePath journal(db_path().value() + FILE_PATH_LITERAL("-journal"));
++  base::FilePath journal_path = sql::Connection::JournalPath(db_path());
+   ASSERT_TRUE(GetPathExists(db_path()));
+-  ASSERT_TRUE(GetPathExists(journal));
++  ASSERT_TRUE(GetPathExists(journal_path));
+ 
+   sql::Connection::Delete(db_path());
+   EXPECT_FALSE(GetPathExists(db_path()));
+-  EXPECT_FALSE(GetPathExists(journal));
++  EXPECT_FALSE(GetPathExists(journal_path));
+ }
+ 
+-// This test manually sets on disk permissions; this doesn't apply to the mojo
+-// fork.
+ #if defined(OS_POSIX) && !defined(MOJO_APPTEST_IMPL)
+-// Test that set_restrict_to_user() trims database permissions so that
+-// only the owner (and root) can read.
+-TEST_F(SQLConnectionTest, UserPermission) {
+-  // If the bots all had a restrictive umask setting such that
+-  // databases are always created with only the owner able to read
+-  // them, then the code could break without breaking the tests.
+-  // Temporarily provide a more permissive umask.
++#if defined(OS_POSIX)  // This test operates on POSIX file permissions.
++TEST_F(SQLConnectionTest, PosixFilePermissions) {
+   db().Close();
+   sql::Connection::Delete(db_path());
+   ASSERT_FALSE(GetPathExists(db_path()));
++
++  // If the bots all had a restrictive umask setting such that databases are
++  // always created with only the owner able to read them, then the code could
++  // break without breaking the tests. Temporarily provide a more permissive
++  // umask.
+   ScopedUmaskSetter permissive_umask(S_IWGRP | S_IWOTH);
++
+   ASSERT_TRUE(db().Open(db_path()));
+ 
+-  // Cause the journal file to be created.  If the default
+-  // journal_mode is changed back to DELETE, then parts of this test
+-  // will need to be updated.
++  // Cause the journal file to be created. If the default journal_mode is
++  // changed back to DELETE, this test will need to be updated.
+   EXPECT_TRUE(db().Execute("CREATE TABLE x (x)"));
+ 
+-  base::FilePath journal(db_path().value() + FILE_PATH_LITERAL("-journal"));
+   int mode;
+ 
+-  // Given a permissive umask, the database is created with permissive
+-  // read access for the database and journal.
+   ASSERT_TRUE(GetPathExists(db_path()));
+-  ASSERT_TRUE(GetPathExists(journal));
+-  mode = base::FILE_PERMISSION_MASK;
+   EXPECT_TRUE(base::GetPosixFilePermissions(db_path(), &mode));
+-  ASSERT_NE((mode & base::FILE_PERMISSION_USER_MASK), mode);
+-  mode = base::FILE_PERMISSION_MASK;
+-  EXPECT_TRUE(base::GetPosixFilePermissions(journal, &mode));
+-  ASSERT_NE((mode & base::FILE_PERMISSION_USER_MASK), mode);
++  ASSERT_EQ(mode, 0600);
+ 
+-  // Re-open with restricted permissions and verify that the modes
+-  // changed for both the main database and the journal.
+-  db().Close();
+-  db().set_restrict_to_user();
+-  ASSERT_TRUE(db().Open(db_path()));
+-  ASSERT_TRUE(GetPathExists(db_path()));
+-  ASSERT_TRUE(GetPathExists(journal));
+-  mode = base::FILE_PERMISSION_MASK;
+-  EXPECT_TRUE(base::GetPosixFilePermissions(db_path(), &mode));
+-  ASSERT_EQ((mode & base::FILE_PERMISSION_USER_MASK), mode);
+-  mode = base::FILE_PERMISSION_MASK;
+-  EXPECT_TRUE(base::GetPosixFilePermissions(journal, &mode));
+-  ASSERT_EQ((mode & base::FILE_PERMISSION_USER_MASK), mode);
++  {
++    base::FilePath journal_path = sql::Connection::JournalPath(db_path());
++    DLOG(ERROR) << "journal_path: " << journal_path;
++    ASSERT_TRUE(GetPathExists(journal_path));
++    EXPECT_TRUE(base::GetPosixFilePermissions(journal_path, &mode));
++    ASSERT_EQ(mode, 0600);
++  }
+ 
+-  // Delete and re-create the database, the restriction should still apply.
++  // Reopen the database and turn on WAL mode.
+   db().Close();
+   sql::Connection::Delete(db_path());
++  ASSERT_FALSE(GetPathExists(db_path()));
+   ASSERT_TRUE(db().Open(db_path()));
+-  ASSERT_TRUE(GetPathExists(db_path()));
+-  ASSERT_FALSE(GetPathExists(journal));
+-  mode = base::FILE_PERMISSION_MASK;
+-  EXPECT_TRUE(base::GetPosixFilePermissions(db_path(), &mode));
+-  ASSERT_EQ((mode & base::FILE_PERMISSION_USER_MASK), mode);
++  ASSERT_TRUE(db().Execute("PRAGMA journal_mode = WAL"));
++  ASSERT_EQ("wal", ExecuteWithResult(&db(), "PRAGMA journal_mode"));
+ 
+-  // Verify that journal creation inherits the restriction.
+-  EXPECT_TRUE(db().Execute("CREATE TABLE x (x)"));
+-  ASSERT_TRUE(GetPathExists(journal));
+-  mode = base::FILE_PERMISSION_MASK;
+-  EXPECT_TRUE(base::GetPosixFilePermissions(journal, &mode));
+-  ASSERT_EQ((mode & base::FILE_PERMISSION_USER_MASK), mode);
++  // The WAL file is created lazily on first change.
++  ASSERT_TRUE(db().Execute("CREATE TABLE foo (a, b)"));
++
++  {
++    base::FilePath wal_path = sql::Connection::WriteAheadLogPath(db_path());
++    ASSERT_TRUE(GetPathExists(wal_path));
++    EXPECT_TRUE(base::GetPosixFilePermissions(wal_path, &mode));
++    ASSERT_EQ(mode, 0600);
++
++    base::FilePath shm_path = sql::Connection::SharedMemoryFilePath(db_path());
++    ASSERT_TRUE(GetPathExists(shm_path));
++    EXPECT_TRUE(base::GetPosixFilePermissions(shm_path, &mode));
++    ASSERT_EQ(mode, 0600);
++  }
+ }
+ #endif  // defined(OS_POSIX)
+ 
+@@ -1058,13 +1059,13 @@ TEST_F(SQLConnectionTest, Attach) {
+   {
+     sql::test::ScopedErrorExpecter expecter;
+     expecter.ExpectError(SQLITE_ERROR);
+-    EXPECT_FALSE(db().AttachDatabase(attach_path, kAttachmentPoint));
++    EXPECT_FALSE(db().AttachDatabase(&db(), attach_path, kAttachmentPoint));
+     ASSERT_TRUE(expecter.SawExpectedErrors());
+   }
+ 
+   // Attach succeeds when the transaction is closed.
+   db().RollbackTransaction();
+-  EXPECT_TRUE(db().AttachDatabase(attach_path, kAttachmentPoint));
++  EXPECT_TRUE(db().AttachDatabase(&db(), attach_path, kAttachmentPoint));
+   EXPECT_TRUE(db().IsSQLValid("SELECT count(*) from other.bar"));
+ 
+   // Queries can touch both databases.
+@@ -1080,14 +1081,14 @@ TEST_F(SQLConnectionTest, Attach) {
+   {
+     sql::test::ScopedErrorExpecter expecter;
+     expecter.ExpectError(SQLITE_ERROR);
+-    EXPECT_FALSE(db().DetachDatabase(kAttachmentPoint));
++    EXPECT_FALSE(db().DetachDatabase(&db(), kAttachmentPoint));
+     EXPECT_TRUE(db().IsSQLValid("SELECT count(*) from other.bar"));
+     ASSERT_TRUE(expecter.SawExpectedErrors());
+   }
+ 
+   // Detach succeeds outside of a transaction.
+   db().RollbackTransaction();
+-  EXPECT_TRUE(db().DetachDatabase(kAttachmentPoint));
++  EXPECT_TRUE(db().DetachDatabase(&db(), kAttachmentPoint));
+ 
+   EXPECT_FALSE(db().IsSQLValid("SELECT count(*) from other.bar"));
+ }
+@@ -1457,8 +1458,8 @@ TEST_F(SQLConnectionTest, CollectDiagnosticInfo) {
+ 
+ #if !defined(MOJO_APPTEST_IMPL)
+ TEST_F(SQLConnectionTest, RegisterIntentToUpload) {
+-  base::FilePath breadcrumb_path(
+-      db_path().DirName().Append(FILE_PATH_LITERAL("sqlite-diag")));
++  base::FilePath breadcrumb_path =
++      db_path().DirName().AppendASCII("sqlite-diag");
+ 
+   // No stale diagnostic store.
+   ASSERT_TRUE(!base::PathExists(breadcrumb_path));
+diff --git a/sql/internal_api_token.h b/sql/internal_api_token.h
+new file mode 100644
+index 000000000000..bb92747426f8
+--- /dev/null
++++ b/sql/internal_api_token.h
+@@ -0,0 +1,25 @@
++// Copyright 2018 The Chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef SQL_INTERNAL_API_TOKEN_H_
++#define SQL_INTERNAL_API_TOKEN_H_
++
++namespace sql {
++
++// Restricts access to APIs internal to the //sql package.
++//
++// This implements Java's package-private via the passkey idiom.
++class InternalApiToken {
++ private:
++  // Must NOT be =default to disallow creation by uniform initialization.
++  InternalApiToken() {}
++  InternalApiToken(const InternalApiToken&) = default;
++
++  friend class ConnectionTestPeer;
++  friend class Recovery;
++};
++
++}  // namespace sql
++
++#endif  // SQL_INTERNAL_API_TOKEN_H_
 diff --git a/sql/recovery.cc b/sql/recovery.cc
-index 64eefa51104efcced21f8caa0ab03a7da92d256a..0fac334df866ac10b8130764602b2ef193b37d3d 100644
+index 64eefa51104e..755d9fb77f9c 100644
 --- a/sql/recovery.cc
 +++ b/sql/recovery.cc
+@@ -154,19 +154,20 @@ std::unique_ptr<Recovery> Recovery::Begin(Connection* connection,
+   // same recovery.
+   if (!connection->is_open()) {
+     // Warn about API mis-use.
+-    DLOG_IF(FATAL, !connection->poisoned_)
++    DCHECK(connection->poisoned(InternalApiToken()))
+         << "Illegal to recover with closed database";
+     return std::unique_ptr<Recovery>();
+   }
+ 
+-  std::unique_ptr<Recovery> r(new Recovery(connection));
+-  if (!r->Init(db_path)) {
++  // Using `new` to access a non-public constructor
++  std::unique_ptr<Recovery> recovery(new Recovery(connection));
++  if (!recovery->Init(db_path)) {
+     // TODO(shess): Should Init() failure result in Raze()?
+-    r->Shutdown(POISON);
++    recovery->Shutdown(POISON);
+     return std::unique_ptr<Recovery>();
+   }
+ 
+-  return r;
++  return recovery;
+ }
+ 
+ // static
+@@ -191,8 +192,7 @@ Recovery::Recovery(Connection* connection)
+     : db_(connection),
+       recover_db_() {
+   // Result should keep the page size specified earlier.
+-  if (db_->page_size_)
+-    recover_db_.set_page_size(db_->page_size_);
++  recover_db_.set_page_size(db_->page_size());
+ 
+   // Files with I/O errors cannot be safely memory-mapped.
+   recover_db_.set_mmap_disabled();
 @@ -244,7 +244,7 @@ bool Recovery::Init(const base::FilePath& db_path) {
    }
  
    // Enable the recover virtual table for this connection.
 -  int rc = recoverVtableInit(recover_db_.db_);
-+  int rc = chrome_sqlite3_recoverVtableInit(recover_db_.db_);
++  int rc = recoverVtableInit(recover_db_.db(InternalApiToken()));
    if (rc != SQLITE_OK) {
      RecordRecoveryEvent(RECOVERY_FAILED_VIRTUAL_TABLE_INIT);
      LOG(ERROR) << "Failed to initialize recover module: "
+@@ -259,7 +259,7 @@ bool Recovery::Init(const base::FilePath& db_path) {
+     return false;
+   }
+ 
+-  if (!recover_db_.AttachDatabase(db_path, "corrupt")) {
++  if (!recover_db_.AttachDatabase(db_path, "corrupt", InternalApiToken())) {
+     RecordRecoveryEvent(RECOVERY_FAILED_ATTACH);
+     UMA_HISTOGRAM_SPARSE_SLOWLY("Sqlite.RecoveryAttachError",
+                                 recover_db_.GetErrorCode());
+@@ -306,16 +306,17 @@ bool Recovery::Backup() {
+ 
+   // Backup the original db from the recovered db.
+   const char* kMain = "main";
+-  sqlite3_backup* backup = sqlite3_backup_init(db_->db_, kMain,
+-                                               recover_db_.db_, kMain);
++  sqlite3_backup* backup =
++      sqlite3_backup_init(db_->db(InternalApiToken()), kMain,
++                          recover_db_.db(InternalApiToken()), kMain);
+   if (!backup) {
+     RecordRecoveryEvent(RECOVERY_FAILED_BACKUP_INIT);
+ 
+     // Error code is in the destination database handle.
+-    int err = sqlite3_extended_errcode(db_->db_);
++    int err = sqlite3_extended_errcode(db_->db(InternalApiToken()));
+     UMA_HISTOGRAM_SPARSE_SLOWLY("Sqlite.RecoveryHandle", err);
+     LOG(ERROR) << "sqlite3_backup_init() failed: "
+-               << sqlite3_errmsg(db_->db_);
++               << sqlite3_errmsg(db_->db(InternalApiToken()));
+ 
+     return false;
+   }
+@@ -334,7 +335,7 @@ bool Recovery::Backup() {
+     RecordRecoveryEvent(RECOVERY_FAILED_BACKUP_STEP);
+     UMA_HISTOGRAM_SPARSE_SLOWLY("Sqlite.RecoveryStep", rc);
+     LOG(ERROR) << "sqlite3_backup_step() failed: "
+-               << sqlite3_errmsg(db_->db_);
++               << sqlite3_errmsg(db_->db(InternalApiToken()));
+   }
+ 
+   // The destination database was locked.  Give up, but leave the data
+@@ -621,7 +622,7 @@ std::unique_ptr<Recovery> Recovery::BeginRecoverDatabase(
+     {
+       Connection probe_db;
+       if (!probe_db.OpenInMemory() ||
+-          probe_db.AttachDatabase(db_path, "corrupt") ||
++          probe_db.AttachDatabase(db_path, "corrupt", InternalApiToken()) ||
+           probe_db.GetErrorCode() != SQLITE_NOTADB) {
+         RecordRecoveryEvent(RECOVERY_FAILED_AUTORECOVERDB_BEGIN);
+         return nullptr;
+diff --git a/sql/recovery_unittest.cc b/sql/recovery_unittest.cc
+index 752688225d97..48db1afe56ba 100644
+--- a/sql/recovery_unittest.cc
++++ b/sql/recovery_unittest.cc
+@@ -951,7 +951,7 @@ void TestPageSize(const base::FilePath& db_prefix,
+   db.Close();
+ 
+   // Make sure the page size is read from the file.
+-  db.set_page_size(0);
++  db.set_page_size(sql::Connection::kDefaultPageSize);
+   ASSERT_TRUE(db.Open(db_path));
+   ASSERT_EQ(expected_final_page_size,
+             ExecuteWithResult(&db, "PRAGMA page_size"));
+@@ -966,11 +966,12 @@ TEST_F(SQLRecoveryTest, PageSize) {
+   const std::string default_page_size =
+       ExecuteWithResult(&db(), "PRAGMA page_size");
+ 
+-  // The database should have the default page size after recovery.
+-  EXPECT_NO_FATAL_FAILURE(
+-      TestPageSize(db_path(), 0, default_page_size, 0, default_page_size));
++  // Check the default page size first.
++  EXPECT_NO_FATAL_FAILURE(TestPageSize(
++      db_path(), sql::Connection::kDefaultPageSize, default_page_size,
++      sql::Connection::kDefaultPageSize, default_page_size));
+ 
+-  // Sync user 32k pages.
++  // Sync uses 32k pages.
+   EXPECT_NO_FATAL_FAILURE(
+       TestPageSize(db_path(), 32768, "32768", 32768, "32768"));
+ 
+@@ -983,8 +984,9 @@ TEST_F(SQLRecoveryTest, PageSize) {
+   // Databases with no page size specified should recover with the new default
+   // page size.  2k has never been the default page size.
+   ASSERT_NE("2048", default_page_size);
+-  EXPECT_NO_FATAL_FAILURE(
+-      TestPageSize(db_path(), 2048, "2048", 0, default_page_size));
++  EXPECT_NO_FATAL_FAILURE(TestPageSize(db_path(), 2048, "2048",
++                                       sql::Connection::kDefaultPageSize,
++                                       default_page_size));
+ }
+ 
+ }  // namespace
+diff --git a/sql/sqlite_features_unittest.cc b/sql/sqlite_features_unittest.cc
+index 88f7802fc02d..97703eae06d0 100644
+--- a/sql/sqlite_features_unittest.cc
++++ b/sql/sqlite_features_unittest.cc
+@@ -334,7 +334,7 @@ TEST_F(SQLiteFeaturesTest, DISABLED_TimeMachine) {
+   ASSERT_TRUE(db().Execute("CREATE TABLE t (id INTEGER PRIMARY KEY)"));
+   db().Close();
+ 
+-  base::FilePath journal(db_path().value() + FILE_PATH_LITERAL("-journal"));
++  base::FilePath journal = sql::Connection::JournalPath(db_path());
+   ASSERT_TRUE(GetPathExists(db_path()));
+   ASSERT_TRUE(GetPathExists(journal));
+ 
+@@ -462,7 +462,7 @@ TEST_F(SQLiteFeaturesTest, SmartAutoVacuum) {
+ // additional work into Chromium shutdown.  Verify that SQLite supports a config
+ // option to not checkpoint on close.
+ TEST_F(SQLiteFeaturesTest, WALNoClose) {
+-  base::FilePath wal_path(db_path().value() + FILE_PATH_LITERAL("-wal"));
++  base::FilePath wal_path = sql::Connection::WriteAheadLogPath(db_path());
+ 
+   // Turn on WAL mode, then verify that the mode changed (WAL is supported).
+   ASSERT_TRUE(db().Execute("PRAGMA journal_mode = WAL"));
 diff --git a/sql/statement.cc b/sql/statement.cc
-index 5778fd0d7daf930b06698e2c632a985e4d254148..a56534526de0be2e5143b0ed25784dbfdd8fc222 100644
+index 5778fd0d7daf..a56534526de0 100644
 --- a/sql/statement.cc
 +++ b/sql/statement.cc
 @@ -217,22 +217,6 @@ ColType Statement::ColumnType(int col) const {
@@ -174,7 +1132,7 @@ index 5778fd0d7daf930b06698e2c632a985e4d254148..a56534526de0be2e5143b0ed25784dbf
    return !!ColumnInt(col);
  }
 diff --git a/sql/statement.h b/sql/statement.h
-index 3bc99ed2924b1756e7359e4be29f0702b1dac962..115895b8501992cc8ca4bd66281e0e5ad7ba28e0 100644
+index 3bc99ed2924b..115895b85019 100644
 --- a/sql/statement.h
 +++ b/sql/statement.h
 @@ -124,7 +124,6 @@ class SQL_EXPORT Statement {
@@ -185,21 +1143,8 @@ index 3bc99ed2924b1756e7359e4be29f0702b1dac962..115895b8501992cc8ca4bd66281e0e5a
  
    // These all take a 0-based argument index.
    bool ColumnBool(int col) const;
-diff --git a/third_party/WebKit/Source/modules/webdatabase/DatabaseAuthorizer.cpp b/third_party/WebKit/Source/modules/webdatabase/DatabaseAuthorizer.cpp
-index f9e5d18cc9c0b59a8c1d8488f340a5de2a539569..f2f0b3e2cdc51f3f86d30ce9159acc89198e8881 100644
---- a/third_party/WebKit/Source/modules/webdatabase/DatabaseAuthorizer.cpp
-+++ b/third_party/WebKit/Source/modules/webdatabase/DatabaseAuthorizer.cpp
-@@ -72,7 +72,7 @@ const FunctionNameList& WhitelistedFunctions() {
-       ({
-           // SQLite functions used to help implement some operations
-           // ALTER TABLE helpers
--          "sqlite_rename_table", "sqlite_rename_trigger",
-+          "sqlite_rename_column", "sqlite_rename_table", "sqlite_rename_test",
-           // GLOB helpers
-           "glob",
-           // SQLite core functions
 diff --git a/third_party/WebKit/Source/modules/webdatabase/sqlite/SQLiteFileSystem.cpp b/third_party/WebKit/Source/modules/webdatabase/sqlite/SQLiteFileSystem.cpp
-index fa7d9daadd0739b6ea11189b238dbc6c59f59287..fc233a1205a0611ed017cdb615fc5e01a90b40d9 100644
+index fa7d9daadd07..fc233a1205a0 100644
 --- a/third_party/WebKit/Source/modules/webdatabase/sqlite/SQLiteFileSystem.cpp
 +++ b/third_party/WebKit/Source/modules/webdatabase/sqlite/SQLiteFileSystem.cpp
 @@ -42,9 +42,10 @@ namespace blink {
@@ -216,3 +1161,36 @@ index fa7d9daadd0739b6ea11189b238dbc6c59f59287..fc233a1205a0611ed017cdb615fc5e01
  }
  
  }  // namespace blink
+diff --git a/third_party/sqlite/BUILD.gn b/third_party/sqlite/BUILD.gn
+index 4f31436ef8e5..d23cf877dd40 100644
+--- a/third_party/sqlite/BUILD.gn
++++ b/third_party/sqlite/BUILD.gn
+@@ -65,9 +65,18 @@ config("chromium_sqlite3_compile_options") {
+     # still exists, but does not work as promised.
+     "SQLITE_DEFAULT_MEMSTATUS=1",
+ 
++    # The default POSIX permissions for a newly created SQLite database.
++    #
++    # If unspecified, this defaults to 0644. All the data stored by Chrome is
++    # private, so our databases use stricter settings.
++    "SQLITE_DEFAULT_FILE_PERMISSIONS=0600",
++
+     # Must match sql::Database::kDefaultPageSize.
+     "SQLITE_DEFAULT_PAGE_SIZE=4096",
+ 
++    # Must match sql::Connection::kDefaultPageSize.
++    "SQLITE_DEFAULT_PAGE_SIZE=4096",
++
+     # By default SQLite pre-allocates 100 pages of pcache data, which will not
+     # be released until the handle is closed.  This is contrary to Chrome's
+     # memory-usage goals.
+@@ -107,6 +116,9 @@ config("chromium_sqlite3_compile_options") {
+     # Chrome calls sqlite3_reset() correctly to reset prepared statements.
+     "SQLITE_OMIT_AUTORESET",
+ 
++    # Chrome does not use sqlite3_column_decltype().
++    "SQLITE_OMIT_DECLTYPE",
++
+     # Chromium does not use sqlite3_{get,free}_table().
+     # Chrome doesn't use sqlite3_compileoption_{used,get}().
+     "SQLITE_OMIT_COMPILEOPTION_DIAGS",

--- a/patches/099-sqlite_api_3_26_0.patch
+++ b/patches/099-sqlite_api_3_26_0.patch
@@ -3,13 +3,6 @@ From: deepak1556 <hop2deep@gmail.com>
 Date: Thu, 13 Dec 2018 04:13:40 +0530
 Subject: sqlite: Update api in //sql and //third_party/WebKit
 
-Refs https://chromium-review.googlesource.com/c/chromium/src/+/1352694
-Refs https://chromium-review.googlesource.com/c/chromium/src/+/1146280
-Refs https://chromium-review.googlesource.com/c/chromium/src/+/1357825
-Refs https://chromium-review.googlesource.com/c/chromium/src/+/1343789
-Refs https://chromium-review.googlesource.com/c/chromium/src/+/1146295
-Refs https://chromium-review.googlesource.com/c/chromium/src/+/1146768
-
 diff --git a/components/password_manager/core/browser/login_database.cc b/components/password_manager/core/browser/login_database.cc
 index e7726d2484b7..1c1d21358c6c 100644
 --- a/components/password_manager/core/browser/login_database.cc
@@ -1151,6 +1144,18 @@ index 3bc99ed2924b..115895b85019 100644
  
    // These all take a 0-based argument index.
    bool ColumnBool(int col) const;
+diff --git a/third_party/WebKit/Source/modules/webdatabase/DatabaseAuthorizer.cpp b/third_party/WebKit/Source/modules/webdatabase/DatabaseAuthorizer.cpp
+index f9e5d18cc9c0..6435d8d0b6b0 100644
+--- a/third_party/WebKit/Source/modules/webdatabase/DatabaseAuthorizer.cpp
++++ b/third_party/WebKit/Source/modules/webdatabase/DatabaseAuthorizer.cpp
+@@ -73,6 +73,7 @@ const FunctionNameList& WhitelistedFunctions() {
+           // SQLite functions used to help implement some operations
+           // ALTER TABLE helpers
+           "sqlite_rename_table", "sqlite_rename_trigger",
++          "sqlite_rename_column", "sqlite_rename_table", "sqlite_rename_test",
+           // GLOB helpers
+           "glob",
+           // SQLite core functions
 diff --git a/third_party/WebKit/Source/modules/webdatabase/sqlite/SQLiteFileSystem.cpp b/third_party/WebKit/Source/modules/webdatabase/sqlite/SQLiteFileSystem.cpp
 index fa7d9daadd07..fc233a1205a0 100644
 --- a/third_party/WebKit/Source/modules/webdatabase/sqlite/SQLiteFileSystem.cpp

--- a/patches/099-sqlite_api_3_26_0.patch
+++ b/patches/099-sqlite_api_3_26_0.patch
@@ -513,10 +513,18 @@ index d7477f57dbfc..d9e24556c547 100644
    if (cache_size_ != 0) {
      const std::string sql =
 diff --git a/sql/connection.h b/sql/connection.h
-index 8b9640785e98..7d936384ca65 100644
+index 8b9640785e98..45358e6b5ffa 100644
 --- a/sql/connection.h
 +++ b/sql/connection.h
-@@ -36,7 +36,6 @@ class ProcessMemoryDump;
+@@ -20,6 +20,7 @@
+ #include "base/memory/ref_counted.h"
+ #include "base/threading/thread_restrictions.h"
+ #include "base/time/time.h"
++#include "sql/internal_api_token.h"
+ #include "sql/sql_export.h"
+ 
+ struct sqlite3;
+@@ -36,7 +37,6 @@ class ProcessMemoryDump;
  namespace sql {
  
  class ConnectionMemoryDumpProvider;
@@ -524,7 +532,7 @@ index 8b9640785e98..7d936384ca65 100644
  class Statement;
  
  // To allow some test classes to be friended.
-@@ -93,7 +92,10 @@ class StatementID {
+@@ -93,7 +93,10 @@ class StatementID {
  
  #define SQL_FROM_HERE sql::StatementID(__FILE__, __LINE__)
  
@@ -536,7 +544,7 @@ index 8b9640785e98..7d936384ca65 100644
  
  // Abstract the source of timing information for metrics (RecordCommitTime, etc)
  // to allow testing control.
-@@ -124,11 +126,20 @@ class SQL_EXPORT Connection {
+@@ -124,11 +127,20 @@ class SQL_EXPORT Connection {
    // Sets the page size that will be used when creating a new database. This
    // must be called before Init(), and will only have an effect on new
    // databases.
@@ -548,7 +556,7 @@ index 8b9640785e98..7d936384ca65 100644
 +  // The page size must be a power of two between 512 and 65536 inclusive.
 +  void set_page_size(int page_size) {
 +    DCHECK(!page_size || (page_size >= 512));
-+    DCHECK(!page_size || !(page_size & (page_size - 1)))
++    DCHECK(!page_size || !(page_size & (page_size - 1)));
 +    DCHECK_GE(page_size, 512);
 +    DCHECK_LE(page_size, 65536);
 +    DCHECK(!(page_size & (page_size - 1)))
@@ -562,7 +570,7 @@ index 8b9640785e98..7d936384ca65 100644
  
    // Sets the number of pages that will be cached in memory by sqlite. The
    // total cache size in bytes will be page_size * cache_size. This must be
-@@ -147,12 +158,6 @@ class SQL_EXPORT Connection {
+@@ -147,12 +159,6 @@ class SQL_EXPORT Connection {
    // This must be called before Open() to have an effect.
    void set_exclusive_locking() { exclusive_locking_ = true; }
  
@@ -575,7 +583,7 @@ index 8b9640785e98..7d936384ca65 100644
    // Call to use alternative status-tracking for mmap.  Usually this is tracked
    // in the meta table, but some databases have no meta table.
    // TODO(shess): Maybe just have all databases use the alt option?
-@@ -387,16 +392,21 @@ class SQL_EXPORT Connection {
+@@ -387,16 +393,21 @@ class SQL_EXPORT Connection {
  
    // Attached databases---------------------------------------------------------
  
@@ -603,7 +611,7 @@ index 8b9640785e98..7d936384ca65 100644
  
    // Statements ----------------------------------------------------------------
  
-@@ -466,6 +476,12 @@ class SQL_EXPORT Connection {
+@@ -466,6 +477,12 @@ class SQL_EXPORT Connection {
    bool DoesViewExist(const char* table_name) const;
  
    // Returns true if a column with the given name exists in the given table.
@@ -616,7 +624,7 @@ index 8b9640785e98..7d936384ca65 100644
    bool DoesColumnExist(const char* table_name, const char* column_name) const;
  
    // Returns sqlite's internal ID for the last inserted row. Valid only
-@@ -507,10 +523,49 @@ class SQL_EXPORT Connection {
+@@ -507,10 +524,49 @@ class SQL_EXPORT Connection {
    // crash server.
    void ReportDiagnosticInfo(int extended_error, Statement* stmt);
  
@@ -669,7 +677,7 @@ index 8b9640785e98..7d936384ca65 100644
    // Allow test-support code to set/reset error expecter.
    friend class test::ScopedErrorExpecter;
  
-@@ -518,6 +573,8 @@ class SQL_EXPORT Connection {
+@@ -518,6 +574,8 @@ class SQL_EXPORT Connection {
    // (they should go through Statement).
    friend class Statement;
  
@@ -678,7 +686,7 @@ index 8b9640785e98..7d936384ca65 100644
    friend class test::ScopedCommitHook;
    friend class test::ScopedScalarFunction;
    friend class test::ScopedMockTimeSource;
-@@ -753,7 +810,6 @@ class SQL_EXPORT Connection {
+@@ -753,7 +811,6 @@ class SQL_EXPORT Connection {
    int page_size_;
    int cache_size_;
    bool exclusive_locking_;
@@ -943,7 +951,7 @@ index 000000000000..bb92747426f8
 +
 +#endif  // SQL_INTERNAL_API_TOKEN_H_
 diff --git a/sql/recovery.cc b/sql/recovery.cc
-index 64eefa51104e..755d9fb77f9c 100644
+index 64eefa51104e..6d4c29d41a1e 100644
 --- a/sql/recovery.cc
 +++ b/sql/recovery.cc
 @@ -154,19 +154,20 @@ std::unique_ptr<Recovery> Recovery::Begin(Connection* connection,
@@ -987,7 +995,7 @@ index 64eefa51104e..755d9fb77f9c 100644
  
    // Enable the recover virtual table for this connection.
 -  int rc = recoverVtableInit(recover_db_.db_);
-+  int rc = recoverVtableInit(recover_db_.db(InternalApiToken()));
++  int rc = chrome_sqlite3_recoverVtableInit(recover_db_.db(InternalApiToken()));
    if (rc != SQLITE_OK) {
      RecordRecoveryEvent(RECOVERY_FAILED_VIRTUAL_TABLE_INIT);
      LOG(ERROR) << "Failed to initialize recover module: "

--- a/patches/099-sqlite_api_3_26_0.patch
+++ b/patches/099-sqlite_api_3_26_0.patch
@@ -1169,36 +1169,3 @@ index fa7d9daadd07..fc233a1205a0 100644
  }
  
  }  // namespace blink
-diff --git a/third_party/sqlite/BUILD.gn b/third_party/sqlite/BUILD.gn
-index 4f31436ef8e5..d23cf877dd40 100644
---- a/third_party/sqlite/BUILD.gn
-+++ b/third_party/sqlite/BUILD.gn
-@@ -65,9 +65,18 @@ config("chromium_sqlite3_compile_options") {
-     # still exists, but does not work as promised.
-     "SQLITE_DEFAULT_MEMSTATUS=1",
- 
-+    # The default POSIX permissions for a newly created SQLite database.
-+    #
-+    # If unspecified, this defaults to 0644. All the data stored by Chrome is
-+    # private, so our databases use stricter settings.
-+    "SQLITE_DEFAULT_FILE_PERMISSIONS=0600",
-+
-     # Must match sql::Database::kDefaultPageSize.
-     "SQLITE_DEFAULT_PAGE_SIZE=4096",
- 
-+    # Must match sql::Connection::kDefaultPageSize.
-+    "SQLITE_DEFAULT_PAGE_SIZE=4096",
-+
-     # By default SQLite pre-allocates 100 pages of pcache data, which will not
-     # be released until the handle is closed.  This is contrary to Chrome's
-     # memory-usage goals.
-@@ -107,6 +116,9 @@ config("chromium_sqlite3_compile_options") {
-     # Chrome calls sqlite3_reset() correctly to reset prepared statements.
-     "SQLITE_OMIT_AUTORESET",
- 
-+    # Chrome does not use sqlite3_column_decltype().
-+    "SQLITE_OMIT_DECLTYPE",
-+
-     # Chromium does not use sqlite3_{get,free}_table().
-     # Chrome doesn't use sqlite3_compileoption_{used,get}().
-     "SQLITE_OMIT_COMPILEOPTION_DIAGS",


### PR DESCRIPTION
##### Description of Change

This is a backport PR similar to the 3-0-x and 3-0-x PRs https://github.com/electron/libchromiumcontent/pull/736 and https://github.com/electron/libchromiumcontent/pull/737 -- here, a followup to https://github.com/electron/libchromiumcontent/pull/733

One difference: the upstream patch to remove auto-vacuum at https://chromium-review.googlesource.com/c/chromium/src/+/1362222 was problematic to backport to `electron-2-0-x`, and its PR description says "no functional changes are expected, because the patch is inert in production", so I've omitted it here.

CC @deepak1556 

##### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `script/update` runs without error
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)