### PR TITLE
fix: expose libgtkui::GetFgColor (backport: 3-0-x)

### DIFF
--- a/patches/common/chromium/libgtkui_export.patch
+++ b/patches/common/chromium/libgtkui_export.patch
@@ -10,6 +10,15 @@ index 665ec57..4ccb088 100644
  
  namespace aura {
  class Window;
+@@ -177,7 +177,7 @@ void ApplyCssToContext(GtkStyleContext* context, const std::string& css);
+ 
+ // Get the 'color' property from the style context created by
+ // GetStyleContextFromCss(|css_selector|).
+-SkColor GetFgColor(const std::string& css_selector);
++LIBGTKUI_EXPORT SkColor GetFgColor(const std::string& css_selector);
+ 
+ ScopedCssProvider GetCssProvider(const std::string& css);
+ 
 @@ -190,7 +190,7 @@ void RenderBackground(const gfx::Size& size,
  // Renders a background from the style context created by
  // GetStyleContextFromCss(|css_selector|) into a 24x24 bitmap and


### PR DESCRIPTION
##### Description of Change
Backport libcc portion of https://github.com/electron/electron/pull/15878 to `3-0-x`
/cc @inukshuk

##### Checklist

- [x] PR description included and stakeholders cc'd
- [x] Patch information is added to appropriate `.patches.yaml`
- [x] `script/update` runs without error
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

##### Notes

`srcipt/update`runs into the (probably) same error as in https://github.com/electron/libchromiumcontent/pull/690#issuecomment-424504022
The patch file actually gets applied, but the script tells otherwise