### PR TITLE
fix: don't call SetInitialBounds on macOS

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -458,3 +458,11 @@ patches:
   description: |
     Update sqlite api for 3.26 in //sql, //content/browser, //third_party/WebKit.
     Backport https://crrev.com/c/1146280/ and https://crrev.com/c/1352694/
+-
+  owners: zcbenz
+  file: fix_initial_size.patch
+  description: |
+    Don't call SetInitialBounds on macOS, since the initial size has already
+    been set by BridgedNativeWidget, and the SetInitialBounds of Widget has bug
+    that will set wrong size.
+    See https://github.com/electron/electron/issues/16015 for more.

--- a/patches/common/chromium/fix_initial_size.patch
+++ b/patches/common/chromium/fix_initial_size.patch
@@ -1,0 +1,14 @@
+diff --git a/ui/views/widget/widget.cc b/ui/views/widget/widget.cc
+index 7054c136dd17..1280fcf35c19 100644
+--- a/ui/views/widget/widget.cc
++++ b/ui/views/widget/widget.cc
+@@ -353,7 +353,9 @@ void Widget::Init(const InitParams& in_params) {
+     UpdateWindowIcon();
+     UpdateWindowTitle();
+     non_client_view_->ResetWindowControls();
++#if !defined(OS_MACOSX)
+     SetInitialBounds(params.bounds);
++#endif
+ 
+     // Perform the initial layout. This handles the case where the size might
+     // not actually change when setting the initial bounds. If it did, child


### PR DESCRIPTION
Don't call SetInitialBounds on macOS, since the initial size has already been set by BridgedNativeWidget, and the SetInitialBounds of Widget has bug that will set wrong size.

Fix https://github.com/electron/electron/issues/16015.