### PR TITLE
fix: Update sandbox rules that target 10.13 exactly to target 10.13 and higher (backport: 2-0-x)

### DIFF
--- a/patches/086-backport-f0c82253.patch
+++ b/patches/086-backport-f0c82253.patch
@@ -22,7 +22,7 @@ index bf3c5530a5d0..f9297fe9f711 100644
    (allow file-read* (subpath "/System/Library/Extensions")))
 +
 +; Needed for VideoToolbox usage - https://crbug.com/767037
-+(allow mach-lookup (global-name "com.apple.coremedia.videodecoder")))
++(allow mach-lookup (global-name "com.apple.coremedia.videodecoder"))
 diff --git a/content/common/common.sb b/content/common/common.sb
 index fbe0ff5c1b6f..f8fe48b2c5b3 100644
 --- a/content/common/common.sb

--- a/patches/086-backport-f0c82253.patch
+++ b/patches/086-backport-f0c82253.patch
@@ -16,14 +16,13 @@ diff --git a/content/browser/gpu.sb b/content/browser/gpu.sb
 index bf3c5530a5d0..f9297fe9f711 100644
 --- a/content/browser/gpu.sb
 +++ b/content/browser/gpu.sb
-@@ -26,3 +26,7 @@
+@@ -26,3 +26,6 @@
  ; https://crbug.com/515280
  (if (param-true? elcap-or-later)
    (allow file-read* (subpath "/System/Library/Extensions")))
 +
 +; Needed for VideoToolbox usage - https://crbug.com/767037
-+(if (param-true? macos-1013)
-+  (allow mach-lookup (global-name "com.apple.coremedia.videodecoder")))
++(allow mach-lookup (global-name "com.apple.coremedia.videodecoder")))
 diff --git a/content/common/common.sb b/content/common/common.sb
 index fbe0ff5c1b6f..f8fe48b2c5b3 100644
 --- a/content/common/common.sb


### PR DESCRIPTION
##### Description of Change
Backport https://chromium-review.googlesource.com/c/chromium/src/+/1200184/
Fixes HW video decoding not working when GPU process is sandboxed on macOS 10.14.
Follow up to https://github.com/electron/libchromiumcontent/pull/558



##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] Patch information is added to appropriate `.patches.yaml`
- [x] `script/update` runs without error
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)