### PR TITLE
fix: FileReader: Make a copy of the ArrayBuffer when returning partial results.

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -496,3 +496,10 @@ patches:
     Skip network adapters that are not in state IfOperStatusUp when probing for
     WPAD via DHCP.
     Backports https://chromium-review.googlesource.com/c/chromium/src/+/946870/
+-
+  owners: marshallofsound
+  file: filereader-make-a-copy-of-the-arraybuffer.patch
+  description: |
+    FileReader: Make a copy of the ArrayBuffer when returning partial results.
+    Backport https://chromium-review.googlesource.com/c/chromium/src/+/1492873
+

--- a/patches/common/chromium/filereader-make-a-copy-of-the-arraybuffer.patch
+++ b/patches/common/chromium/filereader-make-a-copy-of-the-arraybuffer.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marijn Kruisselbrink <mek@chromium.org>
+Date: Thu, 28 Feb 2019 01:44:28 +0000
+Subject: FileReader: Make a copy of the ArrayBuffer when returning
+ partial results.
+
+This is to avoid accidentally ending up with multiple references to the
+same underlying ArrayBuffer. The extra performance overhead of this is
+minimal as usage of partial results is very rare anyway (as can be seen
+on https://www.chromestatus.com/metrics/feature/timeline/popularity/2158).
+
+Bug: 936448
+Change-Id: Icd1081adc1c889829fe7fa4af9cf4440097e8854
+Reviewed-on: https://chromium-review.googlesource.com/c/1492873
+Commit-Queue: Marijn Kruisselbrink <mek@chromium.org>
+Reviewed-by: Adam Klein <adamk@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#636251}
+
+diff --git a/third_party/WebKit/Source/core/fileapi/FileReaderLoader.cpp b/third_party/WebKit/Source/core/fileapi/FileReaderLoader.cpp
+index 629dd5b8de86..9202c9ad0f89 100644
+--- a/third_party/WebKit/Source/core/fileapi/FileReaderLoader.cpp
++++ b/third_party/WebKit/Source/core/fileapi/FileReaderLoader.cpp
+@@ -370,14 +370,16 @@ DOMArrayBuffer* FileReaderLoader::ArrayBufferResult() {
+   if (!raw_data_ || error_code_)
+     return nullptr;
+
+-  DOMArrayBuffer* result = DOMArrayBuffer::Create(raw_data_->ToArrayBuffer());
+-  if (finished_loading_) {
+-    array_buffer_result_ = result;
+-    AdjustReportedMemoryUsageToV8(
+-        -1 * static_cast<int64_t>(raw_data_->ByteLength()));
+-    raw_data_.reset();
++  if (!finished_loading_) {
++    return DOMArrayBuffer::Create(
++        ArrayBuffer::Create(raw_data_->Data(), raw_data_->ByteLength()));
+   }
+-  return result;
++
++  array_buffer_result_ = DOMArrayBuffer::Create(raw_data_->ToArrayBuffer());
++  AdjustReportedMemoryUsageToV8(-1 *
++                                static_cast<int64_t>(raw_data_->ByteLength()));
++  raw_data_.reset();
++  return array_buffer_result_;
+ }
+
+ String FileReaderLoader::StringResult() {
+--
+2.17.2 (Apple Git-113)
+


### PR DESCRIPTION
Backports https://chromium-review.googlesource.com/c/chromium/src/+/1492873

- [x] PR description included and stakeholders cc'd
- [x] Patch information is added to appropriate `.patches.yaml`
- [x] `script/update` runs without error
- [x] PR title follows semantic [commit guidelines]