### PR TITLE
fix: backport IntersectionObserver fixes

### DIFF
--- a/patches/common/chromium/.patches.yaml
+++ b/patches/common/chromium/.patches.yaml
@@ -509,3 +509,17 @@ patches:
     Fix system tray icons being cropped under KDE when they are larger than
     22x22
     Backport https://chromium-review.googlesource.com/c/chromium/src/+/1173235
+-
+  owners: miniak
+  file: intersection-observer-f8bf3f0.patch
+  description: |
+    [IntersectionObserver] Don't snap bounding rects
+    These rects should mirror the behavior of getBoundingClientRect, which doesn't snap.
+    Backport https://chromium-review.googlesource.com/c/chromium/src/+/951640
+-
+  owners: miniak
+  file: intersection-observer-c02251d.patch
+  description: |
+    [IntersectionObserver] Report coordinates as CSS pixels.
+    Prior to this patch, IntersectionObserverEntry was reporting coordinates in device pixels.
+    Backport https://chromium-review.googlesource.com/c/chromium/src/+/1250121

--- a/patches/common/chromium/intersection-observer-c02251d.patch
+++ b/patches/common/chromium/intersection-observer-c02251d.patch
@@ -1,0 +1,85 @@
+diff --git a/third_party/WebKit/Source/core/intersection_observer/IntersectionObservation.cpp b/third_party/WebKit/Source/core/intersection_observer/IntersectionObservation.cpp
+index 2b247f14c56a..9f8c8f0d8bb0 100644
+--- a/third_party/WebKit/Source/core/intersection_observer/IntersectionObservation.cpp
++++ b/third_party/WebKit/Source/core/intersection_observer/IntersectionObservation.cpp
+@@ -73,12 +73,12 @@ void IntersectionObservation::ComputeIntersectionObservations(
+   CHECK(new_threshold_index < kMaxThresholdIndex);
+ 
+   if (last_threshold_index_ != new_threshold_index) {
+-    FloatRect snapped_root_bounds(geometry.RootRect());
++    FloatRect root_bounds(geometry.UnZoomedRootRect());
+     FloatRect* root_bounds_pointer =
+-        should_report_root_bounds_ ? &snapped_root_bounds : nullptr;
++        should_report_root_bounds_ ? &root_bounds : nullptr;
+     IntersectionObserverEntry* new_entry = new IntersectionObserverEntry(
+-        timestamp, new_visible_ratio, FloatRect(geometry.TargetRect()),
+-        root_bounds_pointer, FloatRect(geometry.IntersectionRect()),
++        timestamp, new_visible_ratio, FloatRect(geometry.UnZoomedTargetRect()),
++        root_bounds_pointer, FloatRect(geometry.UnZoomedIntersectionRect()),
+         geometry.DoesIntersect(), Target());
+     Observer()->EnqueueIntersectionObserverEntry(*new_entry);
+     SetLastThresholdIndex(new_threshold_index);
+diff --git a/third_party/WebKit/Source/core/layout/IntersectionGeometry.cpp b/third_party/WebKit/Source/core/layout/IntersectionGeometry.cpp
+index f3ca054d579f..4591fd9fec89 100644
+--- a/third_party/WebKit/Source/core/layout/IntersectionGeometry.cpp
++++ b/third_party/WebKit/Source/core/layout/IntersectionGeometry.cpp
+@@ -8,6 +8,7 @@
+ #include "core/frame/LocalFrameView.h"
+ #include "core/frame/Settings.h"
+ #include "core/html/HTMLFrameOwnerElement.h"
++#include "core/layout/AdjustForAbsoluteZoom.h"
+ #include "core/layout/LayoutBox.h"
+ #include "core/layout/LayoutView.h"
+ #include "core/page/Page.h"
+@@ -220,4 +221,28 @@ void IntersectionGeometry::ComputeGeometry() {
+     MapRootRectToRootFrameCoordinates();
+ }
+ 
++LayoutRect IntersectionGeometry::UnZoomedTargetRect() const {
++  if (!target_)
++    return target_rect_;
++  FloatRect rect(target_rect_);
++  AdjustForAbsoluteZoom::AdjustFloatRect(rect, *target_);
++  return LayoutRect(rect);
++}
++
++LayoutRect IntersectionGeometry::UnZoomedIntersectionRect() const {
++  if (!target_)
++    return intersection_rect_;
++  FloatRect rect(intersection_rect_);
++  AdjustForAbsoluteZoom::AdjustFloatRect(rect, *target_);
++  return LayoutRect(rect);
++}
++
++LayoutRect IntersectionGeometry::UnZoomedRootRect() const {
++  if (!root_)
++    return root_rect_;
++  FloatRect rect(root_rect_);
++  AdjustForAbsoluteZoom::AdjustFloatRect(rect, *root_);
++  return LayoutRect(rect);
++}
++
+ }  // namespace blink
+diff --git a/third_party/WebKit/Source/core/layout/IntersectionGeometry.h b/third_party/WebKit/Source/core/layout/IntersectionGeometry.h
+index 9f5574cb1ce4..e6961353f9e2 100644
+--- a/third_party/WebKit/Source/core/layout/IntersectionGeometry.h
++++ b/third_party/WebKit/Source/core/layout/IntersectionGeometry.h
+@@ -38,12 +38,18 @@ class IntersectionGeometry {
+ 
+   // Client rect in the coordinate system of the frame containing target.
+   LayoutRect TargetRect() const { return target_rect_; }
++  // Target rect in CSS pixels
++  LayoutRect UnZoomedTargetRect() const;
+ 
+   // Client rect in the coordinate system of the frame containing target.
+   LayoutRect IntersectionRect() const { return intersection_rect_; }
++  // Intersection rect in CSS pixels
++  LayoutRect UnZoomedIntersectionRect() const;
+ 
+   // Client rect in the coordinate system of the frame containing root.
+   LayoutRect RootRect() const { return root_rect_; }
++  // Root rect in CSS pixels
++  LayoutRect UnZoomedRootRect() const;
+ 
+   bool DoesIntersect() const { return does_intersect_; }
+ 

--- a/patches/common/chromium/intersection-observer-f8bf3f0.patch
+++ b/patches/common/chromium/intersection-observer-f8bf3f0.patch
@@ -1,0 +1,67 @@
+diff --git a/third_party/WebKit/Source/core/intersection_observer/IntersectionObservation.cpp b/third_party/WebKit/Source/core/intersection_observer/IntersectionObservation.cpp
+index 9b31b29c50b4..2b247f14c56a 100644
+--- a/third_party/WebKit/Source/core/intersection_observer/IntersectionObservation.cpp
++++ b/third_party/WebKit/Source/core/intersection_observer/IntersectionObservation.cpp
+@@ -73,12 +73,12 @@ void IntersectionObservation::ComputeIntersectionObservations(
+   CHECK(new_threshold_index < kMaxThresholdIndex);
+ 
+   if (last_threshold_index_ != new_threshold_index) {
+-    IntRect snapped_root_bounds = geometry.RootIntRect();
+-    IntRect* root_bounds_pointer =
++    FloatRect snapped_root_bounds(geometry.RootRect());
++    FloatRect* root_bounds_pointer =
+         should_report_root_bounds_ ? &snapped_root_bounds : nullptr;
+     IntersectionObserverEntry* new_entry = new IntersectionObserverEntry(
+-        timestamp, new_visible_ratio, geometry.TargetIntRect(),
+-        root_bounds_pointer, geometry.IntersectionIntRect(),
++        timestamp, new_visible_ratio, FloatRect(geometry.TargetRect()),
++        root_bounds_pointer, FloatRect(geometry.IntersectionRect()),
+         geometry.DoesIntersect(), Target());
+     Observer()->EnqueueIntersectionObserverEntry(*new_entry);
+     SetLastThresholdIndex(new_threshold_index);
+diff --git a/third_party/WebKit/Source/core/intersection_observer/IntersectionObserverEntry.cpp b/third_party/WebKit/Source/core/intersection_observer/IntersectionObserverEntry.cpp
+index 86df2fb4913a..0835c425029d 100644
+--- a/third_party/WebKit/Source/core/intersection_observer/IntersectionObserverEntry.cpp
++++ b/third_party/WebKit/Source/core/intersection_observer/IntersectionObserverEntry.cpp
+@@ -11,17 +11,18 @@ namespace blink {
+ IntersectionObserverEntry::IntersectionObserverEntry(
+     DOMHighResTimeStamp time,
+     double intersection_ratio,
+-    const IntRect& bounding_client_rect,
+-    const IntRect* root_bounds,
+-    const IntRect& intersection_rect,
++    const FloatRect& bounding_client_rect,
++    const FloatRect* root_bounds,
++    const FloatRect& intersection_rect,
+     bool is_intersecting,
+     Element* target)
+     : time_(time),
+       intersection_ratio_(intersection_ratio),
+-      bounding_client_rect_(DOMRectReadOnly::FromIntRect(bounding_client_rect)),
+-      root_bounds_(root_bounds ? DOMRectReadOnly::FromIntRect(*root_bounds)
++      bounding_client_rect_(
++          DOMRectReadOnly::FromFloatRect(bounding_client_rect)),
++      root_bounds_(root_bounds ? DOMRectReadOnly::FromFloatRect(*root_bounds)
+                                : nullptr),
+-      intersection_rect_(DOMRectReadOnly::FromIntRect(intersection_rect)),
++      intersection_rect_(DOMRectReadOnly::FromFloatRect(intersection_rect)),
+       target_(target),
+       is_intersecting_(is_intersecting)
+ 
+diff --git a/third_party/WebKit/Source/core/intersection_observer/IntersectionObserverEntry.h b/third_party/WebKit/Source/core/intersection_observer/IntersectionObserverEntry.h
+index 4a7350f565df..e7378ffda557 100644
+--- a/third_party/WebKit/Source/core/intersection_observer/IntersectionObserverEntry.h
++++ b/third_party/WebKit/Source/core/intersection_observer/IntersectionObserverEntry.h
+@@ -21,9 +21,9 @@ class IntersectionObserverEntry final : public ScriptWrappable {
+  public:
+   IntersectionObserverEntry(DOMHighResTimeStamp timestamp,
+                             double intersection_ratio,
+-                            const IntRect& bounding_client_rect,
+-                            const IntRect* root_bounds,
+-                            const IntRect& intersection_rect,
++                            const FloatRect& bounding_client_rect,
++                            const FloatRect* root_bounds,
++                            const FloatRect& intersection_rect,
+                             bool is_intersecting,
+                             Element*);
+ 


### PR DESCRIPTION
##### Description of Change
Backport https://chromium-review.googlesource.com/c/chromium/src/+/951640/
> [IntersectionObserver] Don't snap bounding rects
> These rects should mirror the behavior of getBoundingClientRect, which doesn't snap.

Backport: https://chromium-review.googlesource.com/c/chromium/src/+/1250121/
> [IntersectionObserver] Report coordinates as CSS pixels.
> Prior to this patch, IntersectionObserverEntry was reporting coordinates in device pixels.

##### Checklist
- [x] PR description included and stakeholders cc'd
- [x] Patch information is added to appropriate `.patches.yaml`
- [x] `script/update` runs without error
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)