### PR TITLE
fix: include v8 flags used by electron in ffmpeg build

### DIFF
--- a/chromiumcontent/args/ffmpeg.gn
+++ b/chromiumcontent/args/ffmpeg.gn
@@ -16,6 +16,16 @@ if (target_os != "linux") {
 # https://chromium.googlesource.com/chromium/src/+/master/docs/jumbo.md
 use_jumbo_build = true
 
+# This is required by Node.js
+# See https://github.com/nodejs/node/pull/13242
+v8_promise_internal_field_count = 1
+
+# This is required by Node.js
+# Unconditionally force typed arrays to allocate outside the v8 heap. This
+# is to prevent memory pointers from being moved around that are returned by
+# Buffer::Data()
+v8_typed_array_max_size_in_heap = 0
+
 if (target_cpu == "arm64") {
   # Suppress the linking warning for arm64:
   # warning: libfreetype.so.6, needed by ../../build/linux/debian_jessie_arm64-sysroot/usr/lib/aarch64-linux-gnu/libfontconfig.so, may conflict with libfreetype.so.6


### PR DESCRIPTION
##### Description of Change
<!-- Describe your PR here, in enough detail that a reviewer can understand its purpose easily. -->
mksnapshot comes from the ffmpeg build and needs the same v8 flags used for the static library build.

Right now without those flags the mksnapshot we are distributing for 3-1-x ends up causing segfaults if you use Promises in the snapshot script.  See https://github.com/electron/electron/issues/18420 for more details

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `script/update` runs without error
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)